### PR TITLE
Optimize matching algorithm GEAR-131

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -104,31 +104,31 @@ export const getMatchDetails = (
   )
     return {} as MatchDetails
 
+  const critById: { [id: number]: EligibilityCriterion } = {}
+  for (const crit of criteria) critById[crit.id] = crit
+
+  const fieldById: { [id: number]: MatchFormFieldConfig } = {}
+  for (const field of fields) fieldById[field.id] = field
+
   const fieldOptionLabelMap = getFieldOptionLabelMap(fields)
 
   const getMatchInfo = (critId: number) => {
-    for (const crit of criteria)
-      if (crit.id === critId)
-        for (const field of fields)
-          if (field.id === crit.fieldId)
-            return {
-              fieldName: field.label || field.name,
-              fieldValue: crit.fieldValue,
-              isMatched:
-                values[crit.fieldId] === undefined ||
-                values[crit.fieldId] === ''
-                  ? undefined
-                  : testCriterion(
-                      crit.operator,
-                      crit.fieldValue,
-                      values[crit.fieldId]
-                    ),
-              fieldValueLabel:
-                fieldOptionLabelMap?.[field.id]?.[crit.fieldValue],
-              operator: crit.operator,
-            }
+    const crit = critById[critId]
+    if (crit === undefined) return {} as MatchInfo
 
-    return {} as MatchInfo
+    const field = fieldById[crit.fieldId]
+    if (field === undefined) return {} as MatchInfo
+
+    return {
+      fieldName: field.label || field.name,
+      fieldValue: crit.fieldValue,
+      isMatched:
+        values[crit.fieldId] === undefined || values[crit.fieldId] === ''
+          ? undefined
+          : testCriterion(crit.operator, crit.fieldValue, values[crit.fieldId]),
+      fieldValueLabel: fieldOptionLabelMap?.[field.id]?.[crit.fieldValue],
+      operator: crit.operator,
+    }
   }
 
   const parseAlgorithm = (algorithm: MatchAlgorithm): MatchInfoAlgorithm => ({


### PR DESCRIPTION
Ticket: [GEAR-131](https://pcdc.atlassian.net/browse/GEAR-131)

This PR optimizes the matching algorithm as implemented in `getMatchDetails` utility function, by replacing loops over eligibility criteria and fields in `getMatchInfo` with derived hashmaps. As `getMatchInfo` is repeatedly and recursively invoked in `parseAlgorithm`, this change should help minimize performance degradation with a large set of criteria and/or fields.

In the long run, a further change in the current backend process to generate eligibility criteria will be needed as the current process lead to many duplicates of the same criterion (see discussion in https://github.com/chicagopcdc/gearbox-frontend/pull/42).