### PR TITLE
Add content security policy

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -25,6 +25,10 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>GEARBOx by LLS PedAL</title>
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self' https://www.google-analytics.com https://ssl.google-analytics.com; connect-src 'self' https://www.google-analytics.com; img-src 'self' https://www.google-analytics.com; style-src 'self' 'unsafe-inline';"
+    />
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
This PR adds the following [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP):

```
default-src; 'self'
script-src: 'self' https://www.google-analytics.com https://ssl.google-analytics.com
connect-src: 'self' https://www.google-analytics.com
img-src: 'self' https://www.google-analytics.com
style-src: 'self' 'unsafe-inline'
```

The policy is intended to only allow loading resources from self and [Google Analytics](https://developers.google.com/tag-manager/web/csp#universal_analytics_google_analytics). `unsafe-inline` is added to `style-src` policy to allow inline styles in the source code.