### PR TITLE
Fix match info status modal layout order GEAR-189

### DIFF
--- a/src/components/TrialMatchInfo.tsx
+++ b/src/components/TrialMatchInfo.tsx
@@ -54,7 +54,7 @@ function TrialMatchInfo({
       {showModal ? (
         <div
           id="match-info-modal"
-          className="fixed w-screen h-screen left-0 top-0 flex items-center justify-center z-10"
+          className="fixed w-screen h-screen left-0 top-0 flex items-center justify-center z-50"
           style={{ background: '#cccc' }}
           role="dialog"
           aria-labelledby="eligibility-criteria-dialog-title"


### PR DESCRIPTION
Ticket: [GEAR-189](GEAR-189)

This PR fixes layout order bug introduced by 7f0ef67, as shown in the image:

![image](https://user-images.githubusercontent.com/22449454/136098216-90b16928-8aed-4df4-9b42-20814d3c1b65.png)
