### PR TITLE
Use sticky header for match status info modal GEAR-192

### DIFF
--- a/src/components/TrialMatchInfo.tsx
+++ b/src/components/TrialMatchInfo.tsx
@@ -64,8 +64,8 @@ function TrialMatchInfo({
             className="bg-white overflow-scroll"
             style={{ maxHeight: '95%', maxWidth: '95%' }}
           >
-            <div className="text-sm sm:text-base p-4 sm:p-8">
-              <div className="flex justify-between border-b pb-4 mb-4">
+            <div className="text-sm sm:text-base px-4 pb-4 pt-2 sm:px-8 sm:pb-8">
+              <div className="flex justify-between border-b py-2 sm:py-4 mb-4 sticky top-0 bg-white">
                 <h3
                   id="eligibility-criteria-dialog-title"
                   className="font-bold mr-4"


### PR DESCRIPTION
Ticket: [GEAR-192](https://pcdc.atlassian.net/browse/GEAR-192)

This PR makes the match status info modal header sticky. This improves UX by making the header (title and close button) always available to user when examining a long list of eligibility criteria.


https://user-images.githubusercontent.com/22449454/136285710-1df604eb-2851-4472-83e3-5f1e1ec2b72f.mov

