### PR TITLE
Fix transparent match group title GEAR-197

### DIFF
--- a/src/components/DropdownSection.tsx
+++ b/src/components/DropdownSection.tsx
@@ -11,7 +11,7 @@ type DropdownSectionProps = {
 
 function DropdownSection({
   name,
-  backgroundColor = 'inherit',
+  backgroundColor = 'bg-inherit',
   children,
   isCollapsedAtStart,
 }: DropdownSectionProps) {
@@ -27,12 +27,12 @@ function DropdownSection({
   const isFirefox = navigator.userAgent.includes('Firefox')
   return (
     <section
-      className={`my-4 bg-${backgroundColor} ${
+      className={`my-4 ${backgroundColor} ${
         isFirefox ? 'transition-inherit' : ''
       }`}
     >
       <div
-        className={`flex sticky top-10 py-2 justify-between border-b border-solid border-black bg-${backgroundColor} ${
+        className={`flex sticky top-10 py-2 justify-between border-b border-solid border-black ${backgroundColor} ${
           isFirefox ? 'transition-inherit' : ''
         }`}
       >

--- a/src/components/MatchForm.tsx
+++ b/src/components/MatchForm.tsx
@@ -58,7 +58,7 @@ function MatchForm({
       {config.groups.map((group, i) => (
         <DropdownSection
           key={group.id}
-          backgroundColor="white"
+          backgroundColor="bg-white"
           name={group.name || 'General'}
           isCollapsedAtStart={i !== 0}
         >


### PR DESCRIPTION
Ticket: [GEAR-197](https://pcdc.atlassian.net/browse/GEAR-197)

This PR fixes the `<DropdownSection>` failing to use specified, non-transparent background color for section title:

<image alt="image" src="https://user-images.githubusercontent.com/22449454/137520298-dbf54fd4-04e5-427b-8e62-39d5cf125236.png" width="480" />

This bug was caused by the combination of using partially dynamic TailwindCSS class name:, i.e. `bg-${backgroundColor}`, and using a custom class, `bg-inherit`. While this works on dev server, the custom class `bg-inherit` is omitted in the compiled/purged build output. See https://tailwindcss.com/docs/optimizing-for-production#writing-purgeable-html. 