### PR TITLE
Toggle highlighting criteria based on match status GEAR-198

### DIFF
--- a/src/components/MatchInfoDetails.tsx
+++ b/src/components/MatchInfoDetails.tsx
@@ -3,6 +3,7 @@ import MatchInfoString from './MatchInfoString'
 
 type MatchInfoDetailsProps = {
   isFilterActive?: boolean
+  isHighlightActive?: boolean
   matchInfoAlgorithm: MatchInfoAlgorithm
   matchInfoId?: string
   level?: number
@@ -10,18 +11,23 @@ type MatchInfoDetailsProps = {
 
 function MatchInfoDetails({
   isFilterActive = false,
+  isHighlightActive = false,
   matchInfoAlgorithm,
   matchInfoId = 'match-info',
   level = 0,
 }: MatchInfoDetailsProps) {
   const { criteria, operator, isMatched } = matchInfoAlgorithm
   const space = 8
-  const backgroundColor =
-    isMatched === undefined ? '' : isMatched ? 'bg-blue-100' : 'bg-red-100'
+  const className =
+    !isHighlightActive || isMatched === undefined
+      ? ''
+      : isMatched
+      ? 'bg-blue-100'
+      : 'bg-red-100'
   return isFilterActive && isMatched === false ? null : (
-    <span>
+    <span className={className}>
       {criteria.map((crit, i) => (
-        <span className={backgroundColor} key={`${matchInfoId}-${level}-${i}`}>
+        <span key={`${matchInfoId}-${level}-${i}`}>
           {level > 0 && i === 0 && (
             <>
               <span className="whitespace-pre">
@@ -44,6 +50,7 @@ function MatchInfoDetails({
           {Object.prototype.hasOwnProperty.call(crit, 'criteria') ? (
             <MatchInfoDetails
               isFilterActive={isFilterActive}
+              isHighlightActive={isHighlightActive}
               matchInfoId={matchInfoId}
               matchInfoAlgorithm={crit as MatchInfoAlgorithm}
               level={level + 1}

--- a/src/components/TrialMatchInfo.tsx
+++ b/src/components/TrialMatchInfo.tsx
@@ -5,6 +5,8 @@ import {
   ToggleLeft,
   ToggleRight,
   XCircle,
+  Zap,
+  ZapOff,
 } from 'react-feather'
 import ReactTooltip from 'react-tooltip'
 import type { MatchInfoAlgorithm } from '../model'
@@ -26,12 +28,14 @@ function TrialMatchInfo({
   const [showModal, setShowModal] = useState(false)
   const [showModalOptions, setShowModalOptions] = useState(false)
   const [isFilterActive, setIsFilterActive] = useState(false)
+  const [isHighlightActive, setIsHighlightActive] = useState(false)
 
   const openModal = () => setShowModal(true)
   const closeModal = () => {
     setShowModal(false)
     setShowModalOptions(false)
     setIsFilterActive(false)
+    setIsHighlightActive(false)
   }
   useEffect(() => {
     return closeModal
@@ -53,6 +57,7 @@ function TrialMatchInfo({
   }, [showModal])
   const toggleModalOptions = () => setShowModalOptions((show) => !show)
   const toggleFilter = () => setIsFilterActive((isActive) => !isActive)
+  const toggleHighlight = () => setIsHighlightActive((isActive) => !isActive)
 
   return (
     <>
@@ -145,6 +150,34 @@ function TrialMatchInfo({
                               </div>
                             </ReactTooltip>
                           </li>
+                          <li className="hover:bg-red-100">
+                            <button
+                              className="w-full p-2"
+                              data-for="match-form-filter"
+                              data-tip
+                              onClick={toggleHighlight}
+                            >
+                              {isHighlightActive ? (
+                                <Zap className="inline text" />
+                              ) : (
+                                <ZapOff className="inline text-gray-500" />
+                              )}
+                              <span className="mx-2">Highlight status</span>
+                            </button>
+                            <ReactTooltip
+                              border
+                              borderColor="black"
+                              id="match-form-filter"
+                              effect="solid"
+                              place="bottom"
+                              type="light"
+                            >
+                              <div style={{ maxWidth: '200px' }}>
+                                Highlight relevant criteria if match status is
+                                determined.
+                              </div>
+                            </ReactTooltip>
+                          </li>
                         </ul>
                       </div>
                     )}
@@ -160,6 +193,7 @@ function TrialMatchInfo({
               </div>
               <MatchInfoDetails
                 isFilterActive={isFilterActive}
+                isHighlightActive={isHighlightActive}
                 matchInfoId={matchInfoId}
                 matchInfoAlgorithm={studyMatchInfo}
               />


### PR DESCRIPTION
Ticket: [GEAR-198](https://pcdc.atlassian.net/browse/GEAR-198)

This PR implements highlighting criteria group, i.e. algorithm, based on `isMatched` status in order to help users to examine which part of the matching algorithm contributes to the overall matching status. The toggle button for highlighting is placed under the option menu. 

If the highlight is active, any algorithm with `isMatched` value set to `true` will get light-blue background, while any algorithm with `isMatched` value set to `false` will get light-red background. When parent and child algorithms conflict in their `isMatched` values, the child's value will be used for that part. 

See the following screen recording for demo:

https://user-images.githubusercontent.com/22449454/137549396-9f4d77ca-acdf-4268-a10e-2a834933bad1.mov

