### PR TITLE
Keep user session alive GEAR-199

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { RegisterInput, UserData } from '../model'
 
 export default function useAuth(): {
@@ -57,6 +57,20 @@ export default function useAuth(): {
         .catch(console.error)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
+
+  // keep access token alive
+  const timer = useRef<number | undefined>(undefined)
+  useEffect(() => {
+    if (timer.current === undefined && isAuthenticated)
+      timer.current = window.setInterval(
+        () => fetch('/user/user/'),
+        10 * 60 * 1000 // ten minutes
+      )
+
+    return () => {
+      if (timer.current !== undefined) window.clearInterval(timer.current)
+    }
+  }, [isAuthenticated])
 
   return {
     isAuthenticated,


### PR DESCRIPTION
Ticket: [GEAR-199](https://pcdc.atlassian.net/browse/GEAR-199)

This PR implements a crude method for keeping user session alive by hitting the `/user/user` endpoint on interval (10 mins) to refresh `access_token`.

Please note that requesting `/user/user` is a resource-inefficient way to address the issue and is meant for the temporary use only. This will be changed when a new endpoint for keep-alive is made available.