### PR TITLE
Block requesting page in frame GEAR-227

### DIFF
--- a/nginx/app.conf
+++ b/nginx/app.conf
@@ -7,5 +7,6 @@ server {
         index index.html;
         try_files $uri /index.html;
         expires 30d;
+        add_header X-Frame-Options DENY always;
     }
 }


### PR DESCRIPTION
Ticket: [GEAR-227](https://pcdc.atlassian.net/browse/GEAR-227)

This PR adds `X-Frame-Options: DENY` header to Nginx config in order to block page requests for embedded context (e.g. `<iframe>`). For more info on the header, see [this MDN page](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options.).