### PR TITLE
Align checkbox input label GEAR-242

### DIFF
--- a/src/components/Inputs/Checkbox.tsx
+++ b/src/components/Inputs/Checkbox.tsx
@@ -18,10 +18,10 @@ function Checkbox({
   onChange,
   ...attrs
 }: CheckboxProps) {
-  const className = disabled ? 'text-gray-400' : undefined
+  const className = 'flex' + (disabled ? ' text-gray-400' : '')
 
   const baseInputClassName =
-    'rounded-none border border-solid border-black mr-4'
+    'rounded-none border border-solid border-black inline-block mt-1 mr-4'
   const disabledInputClassName = `${baseInputClassName} border-gray-300 bg-gray-200`
   const checkboxAttrs = {
     ...attrs,


### PR DESCRIPTION
Ticket: [GEAR-242](https://pcdc.atlassian.net/browse/GEAR-242)

This PR adjusts alignment for `<Checkbox>` component so that the checkbox input and its label are always displayed separately. The difference is best shown when the `<Checkbox>` is multi-line. See the following before/after screenshots.

Before:
<img width="496" alt="image" src="https://user-images.githubusercontent.com/22449454/164075641-d6327efa-b0b6-4873-ac15-8f1c163c7e90.png">

After:
<img width="496" alt="image" src="https://user-images.githubusercontent.com/22449454/164075606-42b9e2b1-c918-4322-b320-a0020b9b4f3c.png">