### PR TITLE
Support recovery from data fetching error GEAR-254

### DIFF
--- a/src/hooks/useGearboxData.ts
+++ b/src/hooks/useGearboxData.ts
@@ -89,6 +89,7 @@ export default function useGearboxData(auth: ReturnType<typeof useAuth>) {
 
   return {
     action: {
+      fetchAll,
       updateMatchInput,
     },
     state: {

--- a/src/pages/MatchingPage.tsx
+++ b/src/pages/MatchingPage.tsx
@@ -22,7 +22,7 @@ import {
 export type MatchingPageProps = ReturnType<typeof useGearboxData>
 
 function MatchingPage({ action, state, status }: MatchingPageProps) {
-  const { updateMatchInput } = action
+  const { fetchAll, updateMatchInput } = action
   const { conditions, config, criteria, studies, matchInput } = state
 
   const [isUpdating, setIsUpdating] = useState(false)
@@ -32,6 +32,15 @@ function MatchingPage({ action, state, status }: MatchingPageProps) {
   const [view, setView] = useState<'form' | 'result'>('form')
 
   if (status === 'loading') return <div>Loading...</div>
+  if (status === 'error')
+    return (
+      <>
+        <div className="pb-4">Something went wrong!</div>
+        <Button size="normal" onClick={fetchAll}>
+          Try again
+        </Button>
+      </>
+    )
 
   const defaultValues = getDefaultValues(config)
   const matchDetails = getMatchDetails(criteria, conditions, config, matchInput)


### PR DESCRIPTION
Ticket: [GEAR-254](https://pcdc.atlassian.net/browse/GEAR-254)

This PR supports recovery from GEARBOx data fetching error caused by the failed server response. In implementing this, the PR has updated the `useGearboxData` return value, which now includes new `status` state.


See the following screen recording demonstrating this UX:

https://user-images.githubusercontent.com/22449454/194675462-2558e273-dfe2-4311-bbd2-0b0c518a6731.mov
