### PR TITLE
GEAR-269 Improve matching page error message

### DIFF
--- a/src/pages/MatchingPage.tsx
+++ b/src/pages/MatchingPage.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react-feather'
 import ReactTooltip from 'react-tooltip'
 import Button from '../components/Inputs/Button'
+import LinkExternal from '../components/LinkExternal'
 import MatchForm from '../components/MatchForm'
 import MatchResult from '../components/MatchResult'
 import type useGearboxData from '../hooks/useGearboxData'
@@ -35,10 +36,37 @@ function MatchingPage({ action, state, status }: MatchingPageProps) {
   if (status === 'error')
     return (
       <>
-        <div className="pb-4">Something went wrong!</div>
-        <Button size="normal" onClick={fetchAll}>
-          Try again
-        </Button>
+        <div className="pb-8">
+          <p className="pb-4">Something went wrong! Please try again.</p>
+          <Button size="normal" onClick={fetchAll}>
+            Try again
+          </Button>
+        </div>
+        <div className="pb-4">
+          <p>
+            &quot;Try again&quot; button did not fix the problem? Please try
+            hard refresh.
+          </p>
+          <ul className="list-disc pl-8">
+            <li>
+              Chrome or Firefox: Press <strong>Ctrl + F5</strong> on Windows or{' '}
+              <strong>Cmd + Shift + R</strong> on Mac
+            </li>
+            <li>
+              Safari (Mac): Press <strong>Cmd + Option + R</strong>
+            </li>
+          </ul>
+        </div>
+        <p>
+          Hard refresh did not fix the problem? Please reach out to{' '}
+          <LinkExternal
+            className="underline text-primary"
+            to="mailto:gearbox_help@lists.uchicago.edu"
+          >
+            gearbox_help@lists.uchicago.edu
+          </LinkExternal>
+          .
+        </p>
       </>
     )
 


### PR DESCRIPTION
Ticket: [GEAR-269](https://pcdc.atlassian.net/browse/GEAR-269)

This PR modifies the error message on matching page that is displayed at root route when user is authenticated. The goal is to provide the user with the following additional steps to try if "try again" button fails: 

1. Hard refresh to invalidate browser cache (for desktop users, which constitute GEARBOx's primary audience)
2. Reach out to the help channel

See the following before/after images:

Before:
<img width="600" alt="image" src="https://user-images.githubusercontent.com/22449454/201230694-ac650587-e451-401d-863c-cdd1edf763b9.png">

After:
<img width="600" alt="image" src="https://user-images.githubusercontent.com/22449454/201230619-41fd484c-9bcf-4625-92c2-6a448beb54cd.png">

