### PR TITLE
GEAR-277 - fixed study name and sites on study card based on backend changes

### DIFF
--- a/src/api/studies.ts
+++ b/src/api/studies.ts
@@ -1,4 +1,4 @@
-import type { Study } from '../model'
+import type { Study, StudyApi } from '../model'
 import { fetchGearbox, readCache, writeCache } from './utils'
 
 const LOCAL_STORAGE_KEY = 'gearbox:studies'
@@ -10,7 +10,18 @@ export function getStudies() {
   return fetchGearbox('/gearbox/studies')
     .then((res) => res.json())
     .then(fetch)
-    .then((res) => res.json() as Promise<Study[]>)
+    .then((res) => res.json() as Promise<StudyApi[]>)
+    .then((studiesApi) =>
+      studiesApi.map(
+        (studyApi) =>
+          ({
+            ...studyApi,
+            sites: studyApi.sites
+              .map((site) => site.site)
+              .filter((site) => site.active),
+          } as Study)
+      )
+    )
     .then((data) => {
       writeCache(LOCAL_STORAGE_KEY, JSON.stringify(data))
       return data

--- a/src/components/CriteriaBuilderModal.tsx
+++ b/src/components/CriteriaBuilderModal.tsx
@@ -79,7 +79,7 @@ export function CriteriaBuilderModal({
                 Eligibility Criteria for{' '}
               </span>
               <span className="italic block">
-                {study.code}: {study.title}
+                {study.code}: {study.name}
               </span>
             </h3>
             <div className="min-w-max">

--- a/src/components/TrialCard.tsx
+++ b/src/components/TrialCard.tsx
@@ -50,7 +50,7 @@ function TrialCard({ study, children }: TrialCardProps) {
         </div>
         <div className={styles.field.container}>
           <h3 className={styles.field.title}>Title</h3>
-          <p className={isDropDownOpen ? '' : 'truncate'}>{study.title}</p>
+          <p className={isDropDownOpen ? '' : 'truncate'}>{study.name}</p>
         </div>
       </div>
 
@@ -61,14 +61,14 @@ function TrialCard({ study, children }: TrialCardProps) {
             <p>{study.description}</p>
           </div>
         ) : null}
-        {study.locations?.length > 0 ? (
+        {study.sites?.length > 0 ? (
           <div className={styles.field.container}>
             <h3 className={styles.field.title}>
-              {study.locations.length > 1 ? 'Locations' : 'Location'}
+              {study.sites.length > 1 ? 'Locations' : 'Location'}
             </h3>
             <ul className="list-disc ml-8">
-              {study.locations.map((location) => (
-                <li key={location}>{location}</li>
+              {study.sites.map((site) => (
+                <li key={site.id}>{site.name}</li>
               ))}
             </ul>
           </div>

--- a/src/components/TrialMatchInfo.tsx
+++ b/src/components/TrialMatchInfo.tsx
@@ -70,7 +70,7 @@ function TrialMatchInfo({ study, studyMatchInfo }: TrialMatchInfoProps) {
                     Eligibility Criteria for{' '}
                   </span>
                   <span className="italic block">
-                    {study.code}: {study.title}
+                    {study.code}: {study.name}
                   </span>
                 </h3>
                 <div className="min-w-max">

--- a/src/mock/studies.json
+++ b/src/mock/studies.json
@@ -1,9 +1,9 @@
 [
   {
     "id": 1,
-    "title": "A Study to Test Bone Marrow and Blood in Children With Leukemia That Has Come Back After Treatment or Is Difficult to Treat",
+    "name": "A Study to Test Bone Marrow and Blood in Children With Leukemia That Has Come Back After Treatment or Is Difficult to Treat",
     "code": "APAL2020SC",
-    "locations": [],
+    "sites": [],
     "links": [
       {
         "name": "ClinicalTrials.gov",
@@ -14,9 +14,9 @@
   },
   {
     "id": 2,
-    "title": "Study of Selinexor and Venetoclax in Combination With Chemotherapy in Pediatric and Young Adult Patients With Refractory or Relapsed Acute Myeloid Leukemia",
+    "name": "Study of Selinexor and Venetoclax in Combination With Chemotherapy in Pediatric and Young Adult Patients With Refractory or Relapsed Acute Myeloid Leukemia",
     "code": "SELCLAX",
-    "locations": ["St. Jude Children's Research Hospital"],
+    "sites": [{"id": 1, "name": "St. Jude Children's Research Hospital", "active": true}],
     "links": [
       {
         "name": "ClinicalTrials.gov",
@@ -27,13 +27,13 @@
   },
   {
     "id": 3,
-    "title": "Study of Venetoclax in Combination With Chemotherapy in Pediatric Patients With Refractory or Relapsed Acute Myeloid Leukemia or Acute Leukemia of Ambiguous Lineage",
+    "name": "Study of Venetoclax in Combination With Chemotherapy in Pediatric Patients With Refractory or Relapsed Acute Myeloid Leukemia or Acute Leukemia of Ambiguous Lineage",
     "code": "VENAML",
-    "locations": [
-      "Children's Hospital of Orange County",
-      "Lucille Packard Children's Hospital Stanford University",
-      "UNC Lineberger Comprehensive Cancer Center",
-      "St. Jude Children's Research Hospital"
+    "sites": [
+      {"id": 2, "name": "Children's Hospital of Orange County", "active":  true},
+      {"id": 3, "name": "Lucille Packard Children's Hospital Stanford University", "active":  true},
+      {"id": 4, "name": "UNC Lineberger Comprehensive Cancer Center", "active":  true},
+      {"id": 1, "name": "St. Jude Children's Research Hospital", "active":  true}
     ],
     "links": [
       {
@@ -45,42 +45,17 @@
   },
   {
     "id": 5,
-    "title": "Epigenetic Reprogramming in Relapse/Refractory AML",
+    "name": "Epigenetic Reprogramming in Relapse/Refractory AML",
     "code": "T2016-003",
-    "locations": [
-      "Children's Hospital Los Angeles",
-      "Children's Hospital Orange County",
-      "UCSF School of Medicine",
-      "The Children's Hospital, University of Colorado",
-      "Children's National Medical Center",
-      "University of Miami",
-      "All Children's Hospital",
-      "Children's Healthcare of Atlanta, Emory University",
-      "Lurie Children's Hospital of Chicago",
-      "Johns Hopkins University",
-      "Sidney Kimmel Cancer Center at Johns Hopkins",
-      "National Cancer Institute, Pediatric Oncology Branch",
-      "Dana-Farber Cancer Institute",
-      "C.S. Mott Children's Hospital",
-      "CS Mott Children's Hospital, Ann Arbor",
-      "Children's Hospitals and Clinics of Minnesota",
-      "New York University Medical Center",
-      "Children's Hospital New York-Presbyterian",
-      "Levine Children's Hospital",
-      "Cincinnati Children's Hospital",
-      "Nationwide Children's Hospital",
-      "Oregon Health and Science University",
-      "Children's Hospital of Philadelphia",
-      "Cook Children's Medical Center",
-      "Texas Children's Cancer Center, Baylor",
-      "Primary Children's Hospital",
-      "Seattle Children's Hospital",
-      "Medical College of Wisconsin",
-      "Sydney Children's Hospital",
-      "Children's Hospital at Westmead",
-      "British Columbia Children's Hospital",
-      "Toronto, Ontario, Canada, M5G 1X8",
-      "Sainte Justine University Hospital"
+    "sites": [
+      {"id": 2, "name": "Children's Hospital of Orange County", "active":  true},
+      {"id": 3, "name": "Lucille Packard Children's Hospital Stanford University", "active":  true},
+      {"id": 4, "name": "UNC Lineberger Comprehensive Cancer Center", "active":  true},
+      {"id": 1, "name": "St. Jude Children's Research Hospital", "active":  true},
+      {"id": 5, "name": "Children's Hospital Los Angeles", "active":  true},
+      {"id": 6, "name": "UCSF School of Medicine", "active":  true},
+      {"id": 7, "name": "The Children's Hospital, University of Colorado", "active":  true},
+      {"id": 8, "name": "Children's National Medical Center", "active":  true}
     ],
     "links": [
       {
@@ -92,9 +67,9 @@
   },
   {
     "id": 6,
-    "title": "Liposomal Cytarabine, Daunorubicin, and Gemtuzumab Ozogamicin for the Treatment of Relapsed Refractory Pediatric Patients With Acute Myeloid Leukemia",
+    "name": "Liposomal Cytarabine, Daunorubicin, and Gemtuzumab Ozogamicin for the Treatment of Relapsed Refractory Pediatric Patients With Acute Myeloid Leukemia",
     "code": "2020-0484",
-    "locations": ["M D Anderson Cancer Center"],
+    "sites": [{"id": 9, "name": "M D Anderson Cancer Center", "active": true}],
     "links": [
       {
         "name": "ClinicalTrials.gov",
@@ -105,9 +80,9 @@
   },
   {
     "id": 7,
-    "title": "CD123 Redirected T Cells for AML in Pediatric Subjects",
+    "name": "CD123 Redirected T Cells for AML in Pediatric Subjects",
     "code": "834675",
-    "locations": ["Children's Hospital of Philadelphia"],
+    "sites": [{"id": 10, "name": "Children's Hospital of Philadelphia", "active": true}],
     "links": [
       {
         "name": "ClinicalTrials.gov",
@@ -118,9 +93,9 @@
   },
   {
     "id": 8,
-    "title": "Venetoclax in Children With Relapsed Acute Myeloid Leukemia (AML)",
+    "name": "Venetoclax in Children With Relapsed Acute Myeloid Leukemia (AML)",
     "code": "APAL2020D",
-    "locations": [],
+    "sites": [],
     "links": [
       {
         "name": "ClinicalTrials.gov",
@@ -131,9 +106,9 @@
   },
   {
     "id": 9,
-    "title": "Niclosamide in Pediatric Patients With Relapsed and Refractory AML",
+    "name": "Niclosamide in Pediatric Patients With Relapsed and Refractory AML",
     "code": "PEDSHEMAML0007",
-    "locations": ["Stanford University"],
+    "sites": [{"id": 11, "name": "Stanford University", "active": true}],
     "links": [
       {
         "name": "ClinicalTrials.gov",
@@ -144,9 +119,9 @@
   },
   {
     "id": 10,
-    "title": "Relapsed Pediatric AML to Determine the Safety and Efficacy of the PARP Inhibitor Talazoparib in Combination With Conventional Chemotherapy (PARPAML)",
+    "name": "Relapsed Pediatric AML to Determine the Safety and Efficacy of the PARP Inhibitor Talazoparib in Combination With Conventional Chemotherapy (PARPAML)",
     "code": "PEDSHEMAML0008",
-    "locations": ["Stanford University"],
+    "sites": [{"id": 11, "name": "Stanford University", "active": true}],
     "links": [
       {
         "name": "ClinicalTrials.gov",

--- a/src/model.d.ts
+++ b/src/model.d.ts
@@ -1,11 +1,23 @@
 export type LoadingStatus = 'not started' | 'loading' | 'success' | 'error'
-export type Study = {
+type Site = {
+  id: number
+  active: boolean
+  name: string
+}
+type CommonStudy = {
   id: number
   code: string
-  title: string
+  name: string
   description: string
-  locations: string[]
   links: { name: string; href: string }[]
+}
+
+export type StudyApi = CommonStudy & {
+  sites: { site: Site }[]
+}
+
+export type Study = CommonStudy & {
+  sites: Site[]
 }
 
 export type StudyVersion = {

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -30,42 +30,42 @@ import {
 const studies: Study[] = [
   {
     id: 0,
-    title: "Study 0",
-    code: "S0000",
-    locations: [],
+    name: 'Study 0',
+    code: 'S0000',
+    sites: [],
     links: [
       {
-        name: "ClinicalTrials.gov",
-        href: "https://clinicaltrials.gov/ct2/show/NCT04726241"
-      }
+        name: 'ClinicalTrials.gov',
+        href: 'https://clinicaltrials.gov/ct2/show/NCT04726241',
+      },
     ],
-    description: "Study 0"
+    description: 'Study 0',
   },
   {
     id: 1,
-    title: "Study 1",
-    code: "S0001",
-    locations: [],
+    name: 'Study 1',
+    code: 'S0001',
+    sites: [],
     links: [
       {
-        name: "ClinicalTrials.gov",
-        href: "https://clinicaltrials.gov/ct2/show/NCT04726241"
-      }
+        name: 'ClinicalTrials.gov',
+        href: 'https://clinicaltrials.gov/ct2/show/NCT04726241',
+      },
     ],
-    description: "Study 1"
+    description: 'Study 1',
   },
   {
     id: 2,
-    title: "Study 2",
-    code: "S0002",
-    locations: [],
+    name: 'Study 2',
+    code: 'S0002',
+    sites: [],
     links: [
       {
-        name: "ClinicalTrials.gov",
-        href: "https://clinicaltrials.gov/ct2/show/NCT04726241"
-      }
+        name: 'ClinicalTrials.gov',
+        href: 'https://clinicaltrials.gov/ct2/show/NCT04726241',
+      },
     ],
-    description: "Study 2"
+    description: 'Study 2',
   },
 ]
 const criteria: EligibilityCriterion[] = [


### PR DESCRIPTION
Fixed study name (title) and sites (locations) on the study card based on backend changes

![Screen Shot 2023-08-08 at 11 31 31 AM](https://github.com/chicagopcdc/gearbox-frontend/assets/4490199/2b54b0ae-1f87-4f7b-8549-10344b71ad4e)
