### PR TITLE
GEAR-278 - handles empty study algorithm

### DIFF
--- a/src/components/CriteriaBuilderModal.tsx
+++ b/src/components/CriteriaBuilderModal.tsx
@@ -106,7 +106,9 @@ export function CriteriaBuilderModal({
               </span>
             </h3>
             <div className="min-w-max">
-              <Button onClick={saveCriteria(studyAlgorithmId)}>Save</Button>
+              {!!studyAlgorithmId && (
+                <Button onClick={saveCriteria(studyAlgorithmId)}>Save</Button>
+              )}
               <button
                 className="ml-4 hover:text-red-700"
                 onClick={closeModal}
@@ -116,7 +118,11 @@ export function CriteriaBuilderModal({
               </button>
             </div>
           </div>
-          {loadingStatus === 'not started' || loadingStatus === 'loading' ? (
+          {!studyAlgorithmId ? (
+            <h2 className="font-bold m-4 text-lg">
+              No Study Algorithm Set Yet
+            </h2>
+          ) : loadingStatus === 'not started' || loadingStatus === 'loading' ? (
             <div>Loading...</div>
           ) : loadingStatus === 'error' ? (
             <ErrorRetry retry={fetchQueryBuilderState} />

--- a/src/hooks/useQueryBuilderState.ts
+++ b/src/hooks/useQueryBuilderState.ts
@@ -16,7 +16,7 @@ interface QueryBuilderState {
 
 export function useQueryBuilderState(
   eligibilityCriteriaId: number,
-  studyAlgorithmId: number,
+  studyAlgorithmId: number | null,
   matchForm: MatchFormConfig,
   queryBuilderConfig: Config
 ): [
@@ -39,27 +39,31 @@ export function useQueryBuilderState(
     useState<LoadingStatus>('not started')
   const fetchQueryBuilderState = (
     ecId: number,
-    saId: number,
+    saId: number | null,
     mf: MatchFormConfig,
     qbc: Config
   ) => {
-    setLoadingStatus('loading')
-    getEligibilityCriteriaById(ecId)
-      .then((criteria) => {
-        getStudyAlgorithm(saId).then((algorithm) => {
-          const queryValue = getQueryBuilderValue(algorithm, criteria, mf)
-          setQueryBuilderState((prevState) => ({
-            ...prevState,
-            tree: QbUtils.checkTree(QbUtils.loadTree(queryValue), qbc),
-            config: qbc,
-          }))
-          setLoadingStatus('success')
+    if (saId) {
+      setLoadingStatus('loading')
+      getEligibilityCriteriaById(ecId)
+        .then((criteria) => {
+          getStudyAlgorithm(saId).then((algorithm) => {
+            const queryValue = getQueryBuilderValue(algorithm, criteria, mf)
+            setQueryBuilderState((prevState) => ({
+              ...prevState,
+              tree: QbUtils.checkTree(QbUtils.loadTree(queryValue), qbc),
+              config: qbc,
+            }))
+            setLoadingStatus('success')
+          })
         })
-      })
-      .catch((err) => {
-        console.error(err)
-        setLoadingStatus('error')
-      })
+        .catch((err) => {
+          console.error(err)
+          setLoadingStatus('error')
+        })
+    } else {
+      setLoadingStatus('success')
+    }
   }
 
   useEffect(() => {

--- a/src/model.d.ts
+++ b/src/model.d.ts
@@ -25,7 +25,7 @@ export type StudyVersion = {
   study_version: number
   eligibility_criteria_infos: [
     {
-      study_algorithm_engine_id: number
+      study_algorithm_engine_id: number | null
       eligibility_criteria_id: number
       status: StudyVersionStatus
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,7 +21,6 @@ import {
   JsonRule,
   Utils as QbUtils,
 } from '@react-awesome-query-builder/ui'
-import { GroupProperties } from '@react-awesome-query-builder/core'
 
 export const getFieldOptionLabelMap = (fields: MatchFormFieldConfig[]) => {
   if (fields === undefined) return {}


### PR DESCRIPTION
When the study doesn't have any study algorithm set, the study algorithm id is null. In this case, we don't need to call the backend api but need to show a message and hide the save button.

![Screen Shot 2023-08-23 at 12 01 18 AM](https://github.com/chicagopcdc/gearbox-frontend/assets/4490199/38c42a3d-c0b7-4eae-9330-7ab758507afc)
