### PR TITLE
GEAR-415 - fixed 404 throwing Error

### DIFF
--- a/src/api/eligibilityCriteria.ts
+++ b/src/api/eligibilityCriteria.ts
@@ -26,5 +26,9 @@ export function getEligibilityCriteriaById(id: number) {
 export function buildEligibilityCriteria() {
   return fetchGearbox('/gearbox/build-eligibility-criteria', {
     method: 'POST',
+  }).then((res) => {
+    if (!res.ok) {
+      throw new Error('build eligibility criteria failed')
+    }
   })
 }

--- a/src/api/matchConditions.ts
+++ b/src/api/matchConditions.ts
@@ -20,5 +20,9 @@ export function getMatchConditions() {
 export function buildMatchConditions() {
   return fetchGearbox('/gearbox/build-match-conditions', {
     method: 'POST',
+  }).then((res) => {
+    if (!res.ok) {
+      throw new Error('build match conditions failed')
+    }
   })
 }

--- a/src/api/studies.ts
+++ b/src/api/studies.ts
@@ -29,5 +29,9 @@ export function getStudies() {
 export function buildStudies() {
   return fetchGearbox('/gearbox/build-studies', {
     method: 'POST',
+  }).then((res) => {
+    if (!res.ok) {
+      throw new Error('build studies failed')
+    }
   })
 }

--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -20,8 +20,6 @@ export function fetchGearbox(input: RequestInfo, init: RequestInit = {}) {
       if (status === 401 || status === 403) {
         localStorage.clear()
         logout()
-      } else if (!res.ok) {
-        throw new Error('The API request failed!')
       }
     }
     return res


### PR DESCRIPTION
The reason was due to a recent change that will log out the user if 401 and 403 errors occur, I also let all other non-200 status codes throw an Error and thought it would be handled by the catch block of error handling. However, doing so would also let 404 and other 4xx errors throw errors. I removed the throwing Error code from the general fetch request, but let each request throw Error when needed.  