### PR TITLE
Refine Dockerfile build and Nginx setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,15 @@ FROM quay.io/pcdc/node-lts-alpine:18-alpine as build-stage
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci
-COPY . .
+COPY public ./public
+COPY src ./src
+COPY .env.production ./
+COPY tailwind.config.js ./
+COPY tsconfig.json ./
+COPY postcss.config.js ./
+COPY .eslintrc ./
+COPY .prettierrc ./
+
 RUN npm run build
 
 FROM quay.io/pcdc/nginx:1.22-alpine
@@ -10,12 +18,21 @@ FROM quay.io/pcdc/nginx:1.22-alpine
 COPY --from=build-stage /app/build /usr/share/nginx/html
 COPY ./nginx /etc/nginx/conf.d
 COPY ./dockerStart.sh /dockerStart.sh
+
+RUN apk add libcap
+
 RUN chmod +x /dockerStart.sh \
+    && setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx \
     && chown -R nginx:nginx /usr/share/nginx/html \
     && mkdir -p /var/cache/nginx \
     && chown -R nginx:nginx /var/cache/nginx \
     && touch /var/run/nginx.pid \
-    && chown nginx:nginx /var/run/nginx.pid
+    && chown nginx:nginx /var/run/nginx.pid \
+    && chown -R nginx:nginx /var/log/nginx \
+    && ln -sf /dev/stdout /var/log/nginx/access.log \
+    && ln -sf /dev/stderr /var/log/nginx/error.log \
+    && mkdir -p /var/lib/nginx/tmp/client_body \
+    && chown -R nginx:nginx /var/lib/nginx
 
 USER nginx
 


### PR DESCRIPTION
Limits file copying to only necessary files and directories for the build stage, improving build efficiency. Adds installation of libcap and sets capabilities for Nginx to allow binding to low ports. Enhances Nginx setup with improved permissions, log redirection, and temporary directory creation for better container operation.