### PR TITLE
Document .env.production usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,25 @@ To learn React, check out the [React documentation](https://reactjs.org/).
 ## Contribute
 
 `npx prettier [filepath] -w`
+
+## Running the Application with Docker
+
+This repository includes a Dockerfile and a startup script that build the app and serve the production build with nginx (nginx listens on port 80 inside the container).
+
+Build the Docker image:
+
+```bash
+docker build -t gearbox-frontend .
+```
+
+Run the container (example maps container port 80 to host port 8080):
+
+```bash
+docker run --rm -p 8080:80 gearbox-frontend
+```
+
+After the container starts, open the app in your browser at:
+
+http://localhost:8080
+
+You can also map to a different host port (for example `-p 80:80`) if preferred.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The primary goal of this prototype is to facilitate the GEARBOx development team
 
 For more information on the GEARBOx project, please refer to materials on [this shared folder by Box](https://uchicago.app.box.com/folder/61411306153) (permission required).
 
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app). Note that only environment variables prefixed with `REACT_APP_` are exposed to the frontend code.
 
 ## Available Scripts
 
@@ -55,6 +55,14 @@ To learn React, check out the [React documentation](https://reactjs.org/).
 
 `npx prettier [filepath] -w`
 
+## .env.production
+
+This repository includes a `.env.production` file that is used when creating production builds (for example during `npm run build` or when building the Docker image). Variable values depend on the deployment environment and are typically provided or adjusted by your deployment/CI process.
+
+**Important:** Values from `.env.production` are embedded into the build artifacts at build time. Do not store secrets in this file.
+
+The file is not required for local development (`npm start` will run without it).
+
 ## Running the Application with Docker
 
 This repository includes a Dockerfile and a startup script that build the app and serve the production build with nginx (nginx listens on port 80 inside the container).
@@ -77,6 +85,4 @@ http://localhost:8080
 
 You can also map to a different host port (for example `-p 80:80`) if preferred.
 
-## .env.production
 
-This repository includes a `.env.production` file that is used when creating production builds (for example during `npm run build` or when building the Docker image). Variable values depend on the deployment environment and are typically provided or adjusted by your deployment/CI process. The file is not required for local development (`npm start` will run without it).

--- a/README.md
+++ b/README.md
@@ -76,3 +76,7 @@ After the container starts, open the app in your browser at:
 http://localhost:8080
 
 You can also map to a different host port (for example `-p 80:80`) if preferred.
+
+## .env.production
+
+This repository includes a `.env.production` file that is used when creating production builds (for example during `npm run build` or when building the Docker image). Variable values depend on the deployment environment and are typically provided or adjusted by your deployment/CI process. The file is not required for local development (`npm start` will run without it).


### PR DESCRIPTION
This pull request adds a short section to the README explaining the purpose and usage of the .env.production file.

The repository already includes this file, but its role in production builds was not documented.

This is a documentation-only change. No source code, configuration files, environment variables, or project behavior were modified.