### PR TITLE
fix(a11y): Update aria-labels in DropdownSection for better screen reader support

### DIFF
--- a/src/components/DropdownSection.tsx
+++ b/src/components/DropdownSection.tsx
@@ -54,7 +54,7 @@ function DropdownSection({
               e.preventDefault()
               setOpen(false)
             }}
-            aria-label="Collapse"
+            aria-label="Collapse dropdown"
           >
             <ChevronUp color="#C00" />
           </button>
@@ -64,7 +64,7 @@ function DropdownSection({
               e.preventDefault()
               setOpen(true)
             }}
-            aria-label="Expand"
+            aria-label="Expand dropdown"
           >
             <ChevronDown />
           </button>


### PR DESCRIPTION
## Summary
Updates the `aria-label` attributes in `DropdownSection` component to be more descriptive for screen reader users.

## Related Issue
Fixes #277

## Changes Made
- Changed `aria-label="Collapse"` to `aria-label="Collapse dropdown"`
- Changed `aria-label="Expand"` to `aria-label="Expand dropdown"`

## Why This Change?
The previous labels were too vague for screen reader users. According to WCAG 2.1 guidelines, button labels should describe both the **action** and the **target**. "Collapse" alone doesn't indicate what will be collapsed.

## Testing
- [x] Fixes failing test in `MatchForm.test.tsx` that expected `'Collapse dropdown'`
- [x] Verified with screen reader simulation
- [x] No breaking changes to existing functionality

## Files Changed
- `src/components/DropdownSection.tsx`