### PR TITLE
fix(hooks): Set correct status to 'success' after successful data fetch

### DIFF
--- a/src/hooks/useGearboxData.ts
+++ b/src/hooks/useGearboxData.ts
@@ -41,7 +41,7 @@ export default function useGearboxData(auth: ReturnType<typeof useAuth>) {
           setConfig(config)
           setCriteria(criteria)
           setStudies(studies)
-          setStatus('not started')
+          setStatus('success')
           setImportantQuestionsConfig(importantQuestionsConfig)
         }
       )


### PR DESCRIPTION
## Summary
Fixes the `fetchAll()` function in `useGearboxData` hook that was incorrectly setting status to `'not started'` instead of `'success'` after successfully fetching data.

## Related Issue
Fixes #284

## Problem
The status state machine was broken:
```
Expected: 'not started' → 'sending' → 'success' | 'error'
Actual:   'not started' → 'sending' → 'not started' ❌
```

This caused:
- Success state never detected by consuming components
- Ambiguous state where `'not started'` could mean either "never fetched" or "successfully fetched"
- Any logic checking `status === 'success'` would always fail

## Solution
Changed `setStatus('not started')` to `setStatus('success')` in the `.then()` callback after all data is successfully fetched.

## Testing
- [x] Verified status changes to `'success'` after fetch completes
- [x] No breaking changes to existing functionality

## Files Changed
- `src/hooks/useGearboxData.ts`