### PR TITLE
fix(utils): Correct boolean logic in getDefaultValues for checkbox fields

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -133,7 +133,7 @@ export const getDefaultValues = ({ fields }: MatchFormConfig) => {
 
   for (const { id, type, defaultValue } of fields)
     defaultValues[id] =
-      type !== 'checkbox' && type === 'multiselect' ? [] : defaultValue
+      type === 'checkbox' || type === 'multiselect' ? [] : defaultValue
 
   return defaultValues
 }


### PR DESCRIPTION
## Summary
Fixes a critical boolean logic error in `getDefaultValues()` that caused checkbox fields to receive `undefined` instead of `[]` as their default value.

## Related Issue
Fixes #281

## Problem
The condition for setting empty array default was logically flawed:

```typescript
// BEFORE (Bug):
type !== 'checkbox' && type === 'multiselect' ? [] : defaultValue

// This can NEVER be true for checkbox because:
// If type === 'checkbox', then type !== 'checkbox' is FALSE
// FALSE && anything = FALSE
```

### Truth Table (Before Fix)
| type | `!== 'checkbox'` | `=== 'multiselect'` | AND Result | Gets `[]`? |
|------|------------------|---------------------|------------|------------|
| checkbox | ❌ false | ❌ false | ❌ false | ❌ NO |
| multiselect | ✅ true | ✅ true | ✅ true | ✅ YES |

## Solution
```typescript
// AFTER (Fixed):
type === 'checkbox' || type === 'multiselect' ? [] : defaultValue
```

## Impact
This bug caused:
- `TypeError` when calling `.includes()` on undefined checkbox values
- Incorrect patient-trial matching results
- Form state corruption in `clearShowIfField()`

## Testing
- [x] Checkbox fields now correctly default to `[]`
- [x] Multiselect fields still correctly default to `[]`
- [x] Other field types unchanged

## Files Changed
- `src/utils.ts`