### PR TITLE
fix(MatchForm): Add cleanup effect to prevent memory leak from setTimeout

### DIFF
--- a/src/components/MatchForm.tsx
+++ b/src/components/MatchForm.tsx
@@ -34,6 +34,16 @@ function MatchForm({
   const formEl = useRef<HTMLFormElement>(null)
   const timeoutRef = useRef<NodeJS.Timeout | undefined>()
 
+  // Cleanup timeout on unmount to prevent memory leak and state updates
+  // on unmounted component
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current !== undefined) {
+        clearTimeout(timeoutRef.current)
+      }
+    }
+  }, [])
+
   const handleChange =
     (fieldType: MatchFormFieldConfig['type']) =>
     (e: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
## Summary
Adds a `useEffect` cleanup function to clear pending timeouts when the `MatchForm` component unmounts, preventing memory leaks and React warnings.

## Related Issue
Fixes #278

## Problem
The `handleChange` function uses a debounced timeout (1000ms) to update match input. If the user navigates away before the timeout fires:

1. Component unmounts
2. Timeout fires anyway
3. `setIsUpdating(false)` called on unmounted component
4. React warning: "Can't perform state update on unmounted component"
5. Memory not properly released

## Solution
Added cleanup effect following the same pattern used in `FieldWrapper.tsx`:

```typescript
useEffect(() => {
  return () => {
    if (timeoutRef.current !== undefined) {
      clearTimeout(timeoutRef.current)
    }
  }
}, [])
```

## Testing
- [x] No more React warnings when navigating away during debounce
- [x] Memory properly released on unmount
- [x] Consistent with existing cleanup patterns in codebase

## Files Changed
- `src/components/MatchForm.tsx`