### PR TITLE
fix(api): Remove erroneous .then(fetch) that passes JSON as URL

### DIFF
--- a/src/api/eligibilityCriteria.ts
+++ b/src/api/eligibilityCriteria.ts
@@ -8,8 +8,6 @@ export function getEligibilityCriteria() {
   if (cache !== null) return Promise.resolve(cache)
 
   return fetchGearbox('/gearbox/eligibility-criteria')
-    .then((res) => res.json())
-    .then(fetch)
     .then((res) => res.json() as Promise<EligibilityCriterion[]>)
     .then((data) => {
       writeCache(SESSION_STORAGE_KEY, JSON.stringify(data))

--- a/src/api/studies.ts
+++ b/src/api/studies.ts
@@ -8,8 +8,6 @@ export function getStudies() {
   if (cache !== null) return Promise.resolve(cache)
 
   return fetchGearbox('/gearbox/studies')
-    .then((res) => res.json())
-    .then(fetch)
     .then((res) => res.json() as Promise<{ version: string; studies: Study[] }>)
     .then((res) =>
       res.studies.map((s) => ({


### PR DESCRIPTION
## Summary
Removes the erroneous `.then(fetch)` calls in `getEligibilityCriteria()` and `getStudies()` that were passing parsed JSON objects as URLs to the `fetch()` function.

## Related Issue
Fixes #282

## Problem
Both API functions had a `.then(fetch)` in their promise chain that made no sense:

```typescript
// BEFORE (Bug):
fetchGearbox('/gearbox/studies')
  .then((res) => res.json())  // Returns JSON object
  .then(fetch)                // ❌ Calls fetch(jsonObject) - uses JSON as URL!
  .then((res) => res.json())  // Tries to parse response from garbage URL
```

When `fetch()` receives an object, it calls `.toString()` on it, resulting in:
- `fetch("[object Object]")` 
- Network error or CORS error
- Application cannot load data

**Note:** The bug was masked if data was already cached (uses `readCache()`), so first-time users saw the error immediately.

## Solution
Removed the erroneous `.then(fetch)` from both files:

```typescript
// AFTER (Fixed):
fetchGearbox('/gearbox/studies')
  .then((res) => res.json() as Promise<...>)
  .then((data) => { ... })
```

## Testing
- [x] API calls work correctly without cache
- [x] First-time users can load data
- [x] Cached data still works as before

## Files Changed
- `src/api/eligibilityCriteria.ts`
- `src/api/studies.ts`