### PR TITLE
fix(MatchingPage): Prevent race condition in match data fetching with cleanup

### DIFF
--- a/src/pages/MatchingPage.tsx
+++ b/src/pages/MatchingPage.tsx
@@ -82,9 +82,25 @@ function MatchingPage({
   }, [])
 
   useEffect(() => {
+    let isCancelled = false
     const matchInput = currentUserInput.values
-    getMatchDetails(matchInput).then(setMatchDetails)
-    getMatchGroups(matchInput).then(setMatchGroups)
+
+    Promise.all([getMatchDetails(matchInput), getMatchGroups(matchInput)])
+      .then(([details, groups]) => {
+        if (!isCancelled) {
+          setMatchDetails(details)
+          setMatchGroups(groups)
+        }
+      })
+      .catch((err) => {
+        if (!isCancelled) {
+          console.error('Error fetching match data:', err)
+        }
+      })
+
+    return () => {
+      isCancelled = true
+    }
   }, [currentUserInput])
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
Fixes a race condition where parallel async requests could return out of order, causing stale data to be displayed. Also adds proper cleanup on unmount.

## Related Issue
Fixes #279

## Problem
When `currentUserInput` changes rapidly:

1. Request A fires for input v1
2. User changes input quickly
3. Request B fires for input v2
4. Request B completes first → UI shows correct data
5. Request A completes later → **UI shows STALE data** ❌

Additionally, if component unmounts while requests are pending, state updates are attempted on unmounted component.

## Solution
Implemented the standard React pattern for async effects with cleanup:

```typescript
useEffect(() => {
  let isCancelled = false
  
  Promise.all([getMatchDetails(matchInput), getMatchGroups(matchInput)])
    .then(([details, groups]) => {
      if (!isCancelled) {
        setMatchDetails(details)
        setMatchGroups(groups)
      }
    })
    .catch((err) => {
      if (!isCancelled) {
        console.error('Error fetching match data:', err)
      }
    })

  return () => {
    isCancelled = true
  }
}, [currentUserInput])
```

## Additional Improvements
- Combined parallel requests with `Promise.all` for atomic updates
- Added error handling (previously missing)
- Prevents state updates on unmounted components

## Testing
- [x] Rapid input changes no longer cause stale data
- [x] No React warnings on quick navigation
- [x] Errors are properly logged

## Files Changed
- `src/pages/MatchingPage.tsx`