### PR TITLE
fix(MatchingPage): Use functional state updates to prevent stale closures

### DIFF
--- a/src/pages/MatchingPage.tsx
+++ b/src/pages/MatchingPage.tsx
@@ -123,14 +123,9 @@ function MatchingPage({
       ).then((res) => {
         setCurrentUserInput(res)
         if (showAllUserInput) {
-          setAllUserInput(
-            allUserInput.map((u) => {
-              if (u.id === res.id) {
-                return res
-              } else {
-                return u
-              }
-            })
+          // Use functional update to get latest state, avoiding stale closure
+          setAllUserInput((prevAllUserInput) =>
+            prevAllUserInput.map((u) => (u.id === res.id ? res : u))
           )
         }
       })
@@ -141,7 +136,8 @@ function MatchingPage({
     postUserInput({}, undefined, name).then((res) => {
       setCurrentUserInput(res)
       if (showAllUserInput) {
-        setAllUserInput([...allUserInput, res])
+        // Use functional update to get latest state, avoiding stale closure
+        setAllUserInput((prevAllUserInput) => [...prevAllUserInput, res])
       }
     })
   }


### PR DESCRIPTION
## Summary
Fixes stale closure bugs in `updateMatchInput` and `createMatchInput` functions where `allUserInput` state was captured at function definition time but used in async callbacks.

## Related Issue
Fixes #280

## Problem
The functions captured `allUserInput` in their closure, but used it inside `.then()` callbacks. By the time the callback executed, `allUserInput` could have changed:

```typescript
// BEFORE (Bug):
function updateMatchInput(...) {
  postUserInput(...).then((res) => {
    // allUserInput here is STALE - captured when function was defined!
    setAllUserInput(allUserInput.map(...))
  })
}
```

**Scenario:**
1. `allUserInput = [A, B]` when function defined
2. User triggers update, async request starts
3. User switches input → `allUserInput = [A, B, C]`
4. Request completes, `.then()` runs
5. Closure still has `allUserInput = [A, B]` (stale!)
6. `setAllUserInput([A, B].map(...))` → **C is lost!**

## Solution
Use functional state updates to always get the latest state:

```typescript
// AFTER (Fixed):
setAllUserInput((prevAllUserInput) =>
  prevAllUserInput.map((u) => (u.id === res.id ? res : u))
)

setAllUserInput((prevAllUserInput) => [...prevAllUserInput, res])
```

## Testing
- [x] Rapid operations no longer lose data
- [x] State updates always use current values
- [x] Simplified code with ternary operator

## Files Changed
- `src/pages/MatchingPage.tsx`