### PR TITLE
docs(readme): improve intro copy and contribute section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# GEARBOx front end application prototype
+# GEARBOx Frontend Application Prototype
 
 A simple prototype for the GEARBOx's client-side application, powered by [React](https://reactjs.org/) and [Tailwind CSS](https://tailwindcss.com/).
 
-The primary goal of this prototype is to facilitate the GEARBOx development team's efforts to iterate on different ideas for designing and implementing user interface to the GEARBOx service. The GEARBOx project is still at its early stage, and the scope of this prototype UI application is currently limited to modeling the client-side interactions without sending requests to GEARBOx back end services.
+The primary goal of this prototype is to facilitate the GEARBOx development team's efforts to iterate on different ideas for designing and implementing the user interface for the GEARBOx service. The GEARBOx project is still at its early stage, and the scope of this prototype UI application is currently limited to modeling the client-side interactions without sending requests to GEARBOx backend services.
 
 For more information on the GEARBOx project, please refer to materials on [this shared folder by Box](https://uchicago.app.box.com/folder/61411306153) (permission required).
 
@@ -53,4 +53,5 @@ To learn React, check out the [React documentation](https://reactjs.org/).
 
 ## Contribute
 
-`npx prettier [filepath] -w`
+- Format files with Prettier: `npx prettier <filepath> -w` (e.g., `npx prettier README.md -w`)
+- Create a branch, commit your changes, and open a PR.


### PR DESCRIPTION
 ## Description

Improve README intro text and contribution notes to reduce confusion for new contributors during setup.

The README had inconsistent wording in the title/description (e.g., “front end” vs “Frontend”, “back end” vs “backend”) and a minimal Contribute section that lacked context. This PR applies a docs-only cleanup to improve clarity and onboarding.

## Changes

- Updated the README title casing for consistency (“Frontend”).
- Improved grammar in the project description (clarified “user interface for …”).
- Standardized wording to “backend”.
- Expanded the Contribute section with brief, actionable contribution steps.

## Updated files

- README.md

Fixes  #306

