### PR TITLE
fix: replace Promise.all with Promise.allSettled for partial rendering

### DIFF
--- a/src/api/importantQuestionsConfig.ts
+++ b/src/api/importantQuestionsConfig.ts
@@ -16,8 +16,4 @@ export function getImportantQuestionsConfig() {
       }
       return res.json() as Promise<ImportantQuestionConfig>
     })
-    .catch((error) => {
-      console.error('Error fetching important questions config:', error)
-      return { groups: [] } as ImportantQuestionConfig
-    })
 }

--- a/src/hooks/useGearboxData.ts
+++ b/src/hooks/useGearboxData.ts
@@ -28,6 +28,7 @@ export default function useGearboxData(auth: ReturnType<typeof useAuth>) {
     useState<ImportantQuestionConfig>({ groups: [] })
 
   const fetchAll = () => {
+    if (status === 'sending') return // prevent concurrent fetches
     setStatus('sending')
     setErrors([])
     Promise.allSettled([
@@ -36,50 +37,55 @@ export default function useGearboxData(auth: ReturnType<typeof useAuth>) {
       getEligibilityCriteria(),
       getStudies(),
       getImportantQuestionsConfig(),
-    ]).then((results) => {
-      const [condResult, configResult, critResult, studyResult, iqResult] =
-        results
+    ])
+      .then((results) => {
+        const [condResult, configResult, critResult, studyResult, iqResult] =
+          results
 
-      if (condResult.status === 'fulfilled') setConditions(condResult.value)
-      if (configResult.status === 'fulfilled') setConfig(configResult.value)
-      if (critResult.status === 'fulfilled') setCriteria(critResult.value)
-      if (studyResult.status === 'fulfilled') setStudies(studyResult.value)
-      if (iqResult.status === 'fulfilled')
-        setImportantQuestionsConfig(iqResult.value)
+        if (condResult.status === 'fulfilled') setConditions(condResult.value)
+        if (configResult.status === 'fulfilled') setConfig(configResult.value)
+        if (critResult.status === 'fulfilled') setCriteria(critResult.value)
+        if (studyResult.status === 'fulfilled') setStudies(studyResult.value)
+        if (iqResult.status === 'fulfilled')
+          setImportantQuestionsConfig(iqResult.value)
 
-      // Labels paired inline with results — no separate array that can drift
-      const labeled: [string, PromiseSettledResult<unknown>][] = [
-        ['match conditions', condResult],
-        ['match form config', configResult],
-        ['eligibility criteria', critResult],
-        ['studies', studyResult],
-        ['important questions config', iqResult],
-      ]
-      const failures = labeled.filter(([, r]) => r.status === 'rejected') as [
-        string,
-        PromiseRejectedResult
-      ][]
+        // Labels paired inline with results — no separate array that can drift
+        const labeled: [string, PromiseSettledResult<unknown>][] = [
+          ['match conditions', condResult],
+          ['match form config', configResult],
+          ['eligibility criteria', critResult],
+          ['studies', studyResult],
+          ['important questions config', iqResult],
+        ]
+        const failures = labeled.filter(([, r]) => r.status === 'rejected') as [
+          string,
+          PromiseRejectedResult
+        ][]
 
-      // Log each failure individually to preserve debugging context
-      failures.forEach(([label, { reason }]) =>
-        console.error(`Failed to load ${label}:`, reason)
-      )
+        // Log each failure individually to preserve debugging context
+        failures.forEach(([label, { reason }]) =>
+          console.error(`Failed to load ${label}:`, reason)
+        )
 
-      const failedLabels = failures.map(([label]) => label)
+        const failedLabels = failures.map(([label]) => label)
 
-      if (failedLabels.length === labeled.length) {
-        // Every endpoint failed — treat as full error
-        setErrors(failedLabels.map((l) => `Failed to load ${l}`))
+        if (failedLabels.length === labeled.length) {
+          // Every endpoint failed — treat as full error
+          setErrors(failedLabels.map((l) => `Failed to load ${l}`))
+          setStatus('error')
+        } else if (failedLabels.length > 0) {
+          // Some endpoints failed — partial success
+          setErrors(failedLabels.map((l) => `Failed to load ${l}`))
+          setStatus('partial')
+        } else {
+          // All succeeded
+          setStatus('success')
+        }
+      })
+      .catch((err) => {
+        console.error('Unexpected error processing results:', err)
         setStatus('error')
-      } else if (failedLabels.length > 0) {
-        // Some endpoints failed — partial success
-        setErrors(failedLabels.map((l) => `Could not load ${l}`))
-        setStatus('partial')
-      } else {
-        // All succeeded
-        setStatus('success')
-      }
-    })
+      })
   }
 
   const resetAll = () => {
@@ -94,6 +100,7 @@ export default function useGearboxData(auth: ReturnType<typeof useAuth>) {
   useEffect(() => {
     if (auth.isRegistered) fetchAll() // load data on login
     else resetAll() // clear data on logout
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [auth.isRegistered])
 
   return {

--- a/src/hooks/useGearboxData.ts
+++ b/src/hooks/useGearboxData.ts
@@ -14,6 +14,15 @@ import { getStudies } from '../api/studies'
 import type useAuth from './useAuth'
 import { getImportantQuestionsConfig } from '../api/importantQuestionsConfig'
 
+/** Labels for each endpoint, used in partial-failure error messages. */
+const ENDPOINT_LABELS = [
+  'match conditions',
+  'match form config',
+  'eligibility criteria',
+  'studies',
+  'important questions config',
+] as const
+
 export default function useGearboxData(auth: ReturnType<typeof useAuth>) {
   const [conditions, setConditions] = useState([] as MatchCondition[])
   const [config, setConfig] = useState({
@@ -23,39 +32,58 @@ export default function useGearboxData(auth: ReturnType<typeof useAuth>) {
   const [criteria, setCriteria] = useState([] as EligibilityCriterion[])
   const [studies, setStudies] = useState([] as Study[])
   const [status, setStatus] = useState<ApiStatus>('not started')
+  const [errors, setErrors] = useState<string[]>([])
   const [importantQuestionsConfig, setImportantQuestionsConfig] =
     useState<ImportantQuestionConfig>({ groups: [] })
 
   const fetchAll = () => {
     setStatus('sending')
-    Promise.all([
+    setErrors([])
+    Promise.allSettled([
       getMatchConditions(),
       getMatchFormConfig(),
       getEligibilityCriteria(),
       getStudies(),
       getImportantQuestionsConfig(),
-    ])
-      .then(
-        ([conditions, config, criteria, studies, importantQuestionsConfig]) => {
-          setConditions(conditions)
-          setConfig(config)
-          setCriteria(criteria)
-          setStudies(studies)
-          setStatus('not started')
-          setImportantQuestionsConfig(importantQuestionsConfig)
-        }
-      )
-      .catch((err) => {
-        console.error(err)
+    ]).then((results) => {
+      const [condResult, configResult, critResult, studyResult, iqResult] =
+        results
+
+      if (condResult.status === 'fulfilled') setConditions(condResult.value)
+      if (configResult.status === 'fulfilled') setConfig(configResult.value)
+      if (critResult.status === 'fulfilled') setCriteria(critResult.value)
+      if (studyResult.status === 'fulfilled') setStudies(studyResult.value)
+      if (iqResult.status === 'fulfilled')
+        setImportantQuestionsConfig(iqResult.value)
+
+      const failedLabels = results
+        .map((r, i) => (r.status === 'rejected' ? ENDPOINT_LABELS[i] : null))
+        .filter(
+          (label): label is typeof ENDPOINT_LABELS[number] => label !== null
+        )
+
+      if (failedLabels.length === results.length) {
+        // Every endpoint failed — treat as full error
+        setErrors(failedLabels.map((l) => `Failed to load ${l}`))
         setStatus('error')
-      })
+      } else if (failedLabels.length > 0) {
+        // Some endpoints failed — partial success
+        setErrors(failedLabels.map((l) => `Could not load ${l}`))
+        setStatus('partial')
+      } else {
+        // All succeeded
+        setStatus('success')
+      }
+    })
   }
+
   const resetAll = () => {
     setConditions([])
     setConfig({ groups: [], fields: [] } as MatchFormConfig)
     setCriteria([])
     setStudies([])
     setImportantQuestionsConfig({ groups: [] })
+    setErrors([])
   }
 
   useEffect(() => {
@@ -74,6 +102,7 @@ export default function useGearboxData(auth: ReturnType<typeof useAuth>) {
       studies,
     },
     status,
+    errors,
     importantQuestionsConfig,
   }
 }

--- a/src/hooks/useGearboxData.ts
+++ b/src/hooks/useGearboxData.ts
@@ -14,15 +14,6 @@ import { getStudies } from '../api/studies'
 import type useAuth from './useAuth'
 import { getImportantQuestionsConfig } from '../api/importantQuestionsConfig'
 
-/** Labels for each endpoint, used in partial-failure error messages. */
-const ENDPOINT_LABELS = [
-  'match conditions',
-  'match form config',
-  'eligibility criteria',
-  'studies',
-  'important questions config',
-] as const
-
 export default function useGearboxData(auth: ReturnType<typeof useAuth>) {
   const [conditions, setConditions] = useState([] as MatchCondition[])
   const [config, setConfig] = useState({
@@ -56,13 +47,27 @@ export default function useGearboxData(auth: ReturnType<typeof useAuth>) {
       if (iqResult.status === 'fulfilled')
         setImportantQuestionsConfig(iqResult.value)
 
-      const failedLabels = results
-        .map((r, i) => (r.status === 'rejected' ? ENDPOINT_LABELS[i] : null))
-        .filter(
-          (label): label is typeof ENDPOINT_LABELS[number] => label !== null
-        )
+      // Labels paired inline with results — no separate array that can drift
+      const labeled: [string, PromiseSettledResult<unknown>][] = [
+        ['match conditions', condResult],
+        ['match form config', configResult],
+        ['eligibility criteria', critResult],
+        ['studies', studyResult],
+        ['important questions config', iqResult],
+      ]
+      const failures = labeled.filter(([, r]) => r.status === 'rejected') as [
+        string,
+        PromiseRejectedResult
+      ][]
 
-      if (failedLabels.length === results.length) {
+      // Log each failure individually to preserve debugging context
+      failures.forEach(([label, { reason }]) =>
+        console.error(`Failed to load ${label}:`, reason)
+      )
+
+      const failedLabels = failures.map(([label]) => label)
+
+      if (failedLabels.length === labeled.length) {
         // Every endpoint failed — treat as full error
         setErrors(failedLabels.map((l) => `Failed to load ${l}`))
         setStatus('error')

--- a/src/model.d.ts
+++ b/src/model.d.ts
@@ -1,8 +1,14 @@
-export type ApiStatus = 'not started' | 'sending' | 'success' | 'error'
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export type ApiStatus =
+  | 'not started'
+  | 'sending'
+  | 'success'
+  | 'partial'
+  | 'error'
 type Site = {
   name: string
   country: string | null
-  city: strin | null
+  city: string | null
   state: string | null
   zip: string | null
   create_date: string | null

--- a/src/pages/MatchingPage.tsx
+++ b/src/pages/MatchingPage.tsx
@@ -107,12 +107,14 @@ function MatchingPage({
     currentUserInput,
     studies,
   ])
+  // 'sending' and 'error' return early; 'partial', 'success', and
+  // 'not started' all render the main UI below.
   if (status === 'sending') return <div>Loading...</div>
   if (status === 'error') {
     return ErrorRetry({ retry: fetchAll })
   }
 
-  const partialWarningBanner = errors.length > 0 && (
+  const partialWarningBanner = status === 'partial' && (
     <div
       role="alert"
       className="rounded bg-yellow-50 border border-yellow-200 text-yellow-800 p-4 mb-4"
@@ -311,9 +313,9 @@ function MatchingPage({
       </section>
     </>
   ) : (
-    <>
+    <div className="flex flex-col h-screen">
       {partialWarningBanner}
-      <div className="flex h-screen pb-8">
+      <div className="flex flex-1 min-h-0 pb-8">
         <section className="h-full overflow-scroll w-1/2">
           <h1 className="sticky top-0 bg-white uppercase text-primary font-bold px-4 lg:px-8 py-2 z-10 flex items-end justify-between">
             <span>Patient Information</span>
@@ -442,7 +444,7 @@ function MatchingPage({
           </div>
         </section>
       </div>
-    </>
+    </div>
   )
 }
 

--- a/src/pages/MatchingPage.tsx
+++ b/src/pages/MatchingPage.tsx
@@ -36,6 +36,7 @@ function MatchingPage({
   action,
   state,
   status,
+  errors,
   importantQuestionsConfig,
 }: MatchingPageProps) {
   const { fetchAll } = action
@@ -111,6 +112,27 @@ function MatchingPage({
     return ErrorRetry({ retry: fetchAll })
   }
 
+  const partialWarningBanner = errors.length > 0 && (
+    <div
+      role="alert"
+      className="rounded bg-yellow-50 border border-yellow-200 text-yellow-800 p-4 mb-4"
+    >
+      <p className="font-semibold">Some data could not be loaded:</p>
+      <ul className="list-disc list-inside mt-1">
+        {errors.map((msg) => (
+          <li key={msg}>{msg}</li>
+        ))}
+      </ul>
+      <button
+        type="button"
+        className="mt-2 text-sm underline text-yellow-700 hover:text-yellow-900"
+        onClick={fetchAll}
+      >
+        Try again
+      </button>
+    </div>
+  )
+
   function updateMatchInput(newMatchedInput: MatchFormValues) {
     if (
       JSON.stringify(newMatchedInput) !==
@@ -174,6 +196,7 @@ function MatchingPage({
 
   return screenSize.smAndDown ? (
     <>
+      {partialWarningBanner}
       <div
         className="flex justify-center sticky top-0 bg-white z-10"
         style={{
@@ -288,134 +311,138 @@ function MatchingPage({
       </section>
     </>
   ) : (
-    <div className="flex h-screen pb-8">
-      <section className="h-full overflow-scroll w-1/2">
-        <h1 className="sticky top-0 bg-white uppercase text-primary font-bold px-4 lg:px-8 py-2 z-10 flex items-end justify-between">
-          <span>Patient Information</span>
-          <div
-            className="inline relative font-normal normal-case text-base"
-            onBlur={handleFormOptionsBlur}
-            tabIndex={0} // eslint-disable-line jsx-a11y/no-noninteractive-tabindex
-          >
-            <button
-              className={`px-2 py-1 ${
-                showFormOptions ? 'bg-red-100' : 'hover:bg-red-100'
-              }`}
-              data-for="match-form-menu"
-              data-tip
-              onClick={toggleFormOptions}
+    <>
+      {partialWarningBanner}
+      <div className="flex h-screen pb-8">
+        <section className="h-full overflow-scroll w-1/2">
+          <h1 className="sticky top-0 bg-white uppercase text-primary font-bold px-4 lg:px-8 py-2 z-10 flex items-end justify-between">
+            <span>Patient Information</span>
+            <div
+              className="inline relative font-normal normal-case text-base"
+              onBlur={handleFormOptionsBlur}
+              tabIndex={0} // eslint-disable-line jsx-a11y/no-noninteractive-tabindex
             >
-              <MoreHorizontal className="inline" size="1rem" />
-              <ReactTooltip
-                border
-                borderColor="black"
-                id="match-form-menu"
-                effect="solid"
-                place="left"
-                type="light"
+              <button
+                className={`px-2 py-1 ${
+                  showFormOptions ? 'bg-red-100' : 'hover:bg-red-100'
+                }`}
+                data-for="match-form-menu"
+                data-tip
+                onClick={toggleFormOptions}
               >
-                <span>Options</span>
-              </ReactTooltip>
-            </button>
-            {showFormOptions && (
-              <div className="absolute right-0 origin-top-right w-44 bg-white border border-gray-300 shadow-md mt-2 p-1">
-                <ul className="w-full text-sm text-center">
-                  <li className="hover:bg-red-100">
-                    <button
-                      className="w-full p-2"
-                      data-for="match-form-filter"
-                      data-tip
-                      onClick={toggleFilter}
-                    >
-                      {isFilterActive ? (
-                        <ToggleRight className="inline text" />
-                      ) : (
-                        <ToggleLeft className="inline text-gray-500" />
-                      )}
-                      <span className="mx-2">Filter questions</span>
-                    </button>
-                    <ReactTooltip
-                      border
-                      borderColor="black"
-                      id="match-form-filter"
-                      effect="solid"
-                      place="left"
-                      type="light"
-                    >
-                      <div style={{ maxWidth: '200px' }}>
-                        Filter to display the relevant questions only or see all
-                      </div>
-                    </ReactTooltip>
-                  </li>
-                  <li className="hover:bg-red-100">
-                    <button className="w-full p-2" onClick={handleReset}>
-                      <RotateCcw className="inline mr-2" size="1rem" />
-                      Reset
-                    </button>
-                  </li>
-                </ul>
-              </div>
-            )}
+                <MoreHorizontal className="inline" size="1rem" />
+                <ReactTooltip
+                  border
+                  borderColor="black"
+                  id="match-form-menu"
+                  effect="solid"
+                  place="left"
+                  type="light"
+                >
+                  <span>Options</span>
+                </ReactTooltip>
+              </button>
+              {showFormOptions && (
+                <div className="absolute right-0 origin-top-right w-44 bg-white border border-gray-300 shadow-md mt-2 p-1">
+                  <ul className="w-full text-sm text-center">
+                    <li className="hover:bg-red-100">
+                      <button
+                        className="w-full p-2"
+                        data-for="match-form-filter"
+                        data-tip
+                        onClick={toggleFilter}
+                      >
+                        {isFilterActive ? (
+                          <ToggleRight className="inline text" />
+                        ) : (
+                          <ToggleLeft className="inline text-gray-500" />
+                        )}
+                        <span className="mx-2">Filter questions</span>
+                      </button>
+                      <ReactTooltip
+                        border
+                        borderColor="black"
+                        id="match-form-filter"
+                        effect="solid"
+                        place="left"
+                        type="light"
+                      >
+                        <div style={{ maxWidth: '200px' }}>
+                          Filter to display the relevant questions only or see
+                          all
+                        </div>
+                      </ReactTooltip>
+                    </li>
+                    <li className="hover:bg-red-100">
+                      <button className="w-full p-2" onClick={handleReset}>
+                        <RotateCcw className="inline mr-2" size="1rem" />
+                        Reset
+                      </button>
+                    </li>
+                  </ul>
+                </div>
+              )}
+            </div>
+          </h1>
+          {showAllUserInput && (
+            <div className="flex flex-col px-4 lg:px-8 pt-4">
+              <label htmlFor="userInputSelect" className="mb-1">
+                User Input
+              </label>
+              <select
+                id="userInputSelect"
+                onChange={loadUserInput}
+                value={currentUserInput.id || ''}
+              >
+                <option disabled value="">
+                  Select One
+                </option>
+                {allUserInput
+                  .filter((userInput) => !!userInput.name)
+                  .map((userInput) => (
+                    <option key={userInput.id} value={userInput.id}>
+                      {userInput.name}
+                    </option>
+                  ))}
+              </select>
+              <Button otherClassName="mt-4 w-1/2" onClick={openModal}>
+                Add New User Input
+              </Button>
+            </div>
+          )}
+          {showModal && (
+            <UserInputModal
+              closeModal={closeModal}
+              createMatchInput={createMatchInput}
+            />
+          )}
+          <div className="px-4 lg:px-8 pb-4">
+            <MatchForm
+              {...{
+                config: { groups: config.groups, fields: markedFields },
+                matchInput: currentUserInput.values,
+                isFilterActive,
+                updateMatchInput,
+                setIsUpdating,
+                importantQuestionsConfig,
+              }}
+            />
           </div>
-        </h1>
-        {showAllUserInput && (
-          <div className="flex flex-col px-4 lg:px-8 pt-4">
-            <label htmlFor="userInputSelect" className="mb-1">
-              User Input
-            </label>
-            <select
-              id="userInputSelect"
-              onChange={loadUserInput}
-              value={currentUserInput.id || ''}
-            >
-              <option disabled value="">
-                Select One
-              </option>
-              {allUserInput
-                .filter((userInput) => !!userInput.name)
-                .map((userInput) => (
-                  <option key={userInput.id} value={userInput.id}>
-                    {userInput.name}
-                  </option>
-                ))}
-            </select>
-            <Button otherClassName="mt-4 w-1/2" onClick={openModal}>
-              Add New User Input
-            </Button>
+        </section>
+        <section className="h-full overflow-scroll w-1/2">
+          <h1 className="sticky top-0 bg-white uppercase text-primary font-bold pl-4 lg:pl-8 py-2 z-10">
+            Open Trials
+          </h1>
+          <div
+            className={`px-4 lg:px-8 pb-4 transition-colors duration-300 ${
+              isUpdating ? 'bg-gray-100' : 'bg-white'
+            }`}
+          >
+            <MatchResult {...{ matchDetails, matchGroups, studies }} />
           </div>
-        )}
-        {showModal && (
-          <UserInputModal
-            closeModal={closeModal}
-            createMatchInput={createMatchInput}
-          />
-        )}
-        <div className="px-4 lg:px-8 pb-4">
-          <MatchForm
-            {...{
-              config: { groups: config.groups, fields: markedFields },
-              matchInput: currentUserInput.values,
-              isFilterActive,
-              updateMatchInput,
-              setIsUpdating,
-              importantQuestionsConfig,
-            }}
-          />
-        </div>
-      </section>
-      <section className="h-full overflow-scroll w-1/2">
-        <h1 className="sticky top-0 bg-white uppercase text-primary font-bold pl-4 lg:pl-8 py-2 z-10">
-          Open Trials
-        </h1>
-        <div
-          className={`px-4 lg:px-8 pb-4 transition-colors duration-300 ${
-            isUpdating ? 'bg-gray-100' : 'bg-white'
-          }`}
-        >
-          <MatchResult {...{ matchDetails, matchGroups, studies }} />
-        </div>
-      </section>
-    </div>
+        </section>
+      </div>
+    </>
   )
 }
 


### PR DESCRIPTION
## Summary

Migrates `useGearboxData` from `Promise.all` to `Promise.allSettled` so that one failing endpoint no longer takes down the entire application. Introduces a `'partial'` status that allows the UI to render successfully loaded data while surfacing a targeted warning for any endpoints that failed.

**Closes #331**  
**Related:** #284 (status bug — fixed as a side effect: `'not started'` → `'success'`)

---

## Changes

**`src/model.d.ts`**
- Added `'partial'` to the `ApiStatus` union type

**`src/hooks/useGearboxData.ts`**
- Replaced `Promise.all` with `Promise.allSettled`
- Each result is now checked individually — fulfilled results update state, rejected results are collected
- New `errors` state array tracks which endpoints failed with human-readable labels
- Status logic:
  - All succeed → `'success'`
  - Some fail → `'partial'`
  - All fail → `'error'`
- Fixed the `setStatus('not started')` bug from #284 — now correctly sets `'success'`
- New `errors` array is returned alongside `status` for consuming components

**`src/pages/MatchingPage.tsx`**
- Destructures new `errors` prop from `useGearboxData`
- Renders a non-blocking yellow warning banner when `status === 'partial'`
- Banner lists which specific data sources failed to load
- Includes a "Try again" button that calls `fetchAll()`
- Banner appears in both mobile and desktop layouts

---

## Before / After

| Scenario | Before | After |
|----------|--------|-------|
| 1 of 5 endpoints returns 500 | Full-page error screen, zero data | App loads with 4/5 data sources, yellow banner warns about the failed one |
| All 5 endpoints succeed | `status = 'not started'` (wrong) | `status = 'success'` (correct) |
| All 5 endpoints fail | `status = 'error'` | `status = 'error'` (unchanged) |
| User clicks "Try Again" | Re-fetches all 5, including the 4 that were fine | Same, but now partial success is possible |

---

## Testing

1. Open DevTools → Network → Block any single gearbox endpoint
2. Reload the app
3. **Expected:** App loads with available data + yellow warning banner listing the blocked endpoint
4. Unblock the endpoint, click "Try again" in the banner
5. **Expected:** Banner disappears, status becomes `'success'`

---

## Checklist

- [x] No new dependencies
- [x] TypeScript compiles with zero errors
- [x] `ApiStatus` type is backward-compatible (existing `'error'` / `'sending'` checks still work)
- [x] Both mobile and desktop layouts render the partial warning banner
- [x] `role="alert"` on the banner for screen reader accessibility
