### PR TITLE
fix: remove throw-during-render in RegisterForm and DocumentReviewForm

### DIFF
--- a/src/components/DocumentReviewForm.tsx
+++ b/src/components/DocumentReviewForm.tsx
@@ -18,7 +18,6 @@ function DocumentReviewForm({
   onReview,
 }: DocumentReviewFormProps) {
   const [error, setError] = useState(null as Error | null)
-  if (error) throw error
 
   const fieldsConfig: RegisterFormFieldConfig[] = []
   const initialValues: RegisterInput['reviewStatus'] = {}
@@ -44,17 +43,29 @@ function DocumentReviewForm({
 
   function handleSubmit(e: React.SyntheticEvent) {
     e.preventDefault()
+    setError(null)
 
     const status: RegisterInput['reviewStatus'] = initialValues
     const formData = new FormData(e.target as HTMLFormElement)
     for (const [k, v] of formData.entries()) status[Number(k)] = v === 'on'
 
     setIsSubmitting(true)
-    onReview(status).catch(setError)
+    onReview(status).catch((err) => {
+      setError(err instanceof Error ? err : new Error(String(err)))
+      setIsSubmitting(false)
+    })
   }
 
   return (
     <form onSubmit={handleSubmit}>
+      {error && (
+        <div
+          role="alert"
+          className="rounded bg-red-50 border border-red-200 text-red-700 p-4 mb-4"
+        >
+          Something went wrong: {error.message}. Please try again.
+        </div>
+      )}
       {fieldsConfig.map((fieldConfig) => (
         <div className="my-4" key={fieldConfig.name}>
           <Field config={fieldConfig} />

--- a/src/components/RegisterForm.tsx
+++ b/src/components/RegisterForm.tsx
@@ -17,7 +17,6 @@ type RegisterUserInput = Omit<RegisterInput, 'reviewStatus' | 'accessCde'>
 
 function RegisterForm({ docsToBeReviewed, onRegister }: RegisterFormProps) {
   const [error, setError] = useState(null as Error | null)
-  if (error) throw error
 
   const userFieldsConfig: RegisterFormFieldConfig[] = [
     {
@@ -125,6 +124,7 @@ function RegisterForm({ docsToBeReviewed, onRegister }: RegisterFormProps) {
   useEffect(() => () => setIsSubmitting(false), [])
   function handleSubmit(e: React.SyntheticEvent) {
     e.preventDefault()
+    setError(null)
 
     const user = { ...initialUser }
     const reviewStatus = { ...initialReviewStatus }
@@ -144,11 +144,22 @@ function RegisterForm({ docsToBeReviewed, onRegister }: RegisterFormProps) {
       reviewStatus,
       role: role === 'other' && roleOther !== undefined ? roleOther : role,
       ...rest,
-    }).catch(setError)
+    }).catch((err) => {
+      setError(err instanceof Error ? err : new Error(String(err)))
+      setIsSubmitting(false)
+    })
   }
 
   return (
     <form onSubmit={handleSubmit} onChange={handleUserChange}>
+      {error && (
+        <div
+          role="alert"
+          className="rounded bg-red-50 border border-red-200 text-red-700 p-4 mb-4"
+        >
+          Something went wrong: {error.message}. Please try again.
+        </div>
+      )}
       {userFieldsConfig.map(
         (fieldConfig) =>
           (fieldConfig.name !== 'roleOther' || showRoleOther) && (


### PR DESCRIPTION
## Summary

Removes the `if (error) throw error` pattern from both `RegisterForm` and `DocumentReviewForm`. Submission errors are now displayed inline with a styled error banner instead of crashing the form via the ErrorBoundary. Users can read the error message and retry without reloading the page.

**Closes #332**

---

## Changes

**`src/components/RegisterForm.tsx`**
- Removed `if (error) throw error` synchronous throw during render
- Added `setError(null)` at the start of `handleSubmit` to clear previous errors on retry
- Changed `.catch(setError)` to `.catch((err) => { setError(...); setIsSubmitting(false) })` so the submit button re-enables after failure
- Added inline error banner with `role="alert"` above the form fields

**`src/components/DocumentReviewForm.tsx`**
- Identical changes as RegisterForm:
- Removed throw-during-render
- Added error clearing on retry
- Added `setIsSubmitting(false)` in catch block
- Added inline error banner

---

## Before / After

| Scenario | Before | After |
|----------|--------|-------|
| Submit fails (network error) | Form disappears, ErrorBoundary fallback renders permanently | Red error banner appears above the form, form stays usable |
| User wants to retry | Must reload the entire page | Clicks "Submit" again — previous error clears automatically |
| Submit button state after error | Stuck in "Registering..." / "Completing..." state | Resets to normal label, re-enabled for retry |
| Truly unexpected errors | Caught by ErrorBoundary | Still caught by ErrorBoundary (no throw removed for non-submission errors) |

---

## Checklist

- [x] No new dependencies
- [x] TypeScript compiles with zero errors
- [x] Both forms display inline error messages
- [x] Submit button re-enables after failure
- [x] `role="alert"` for screen reader accessibility
- [x] Error clears on retry (no stale messages)
- [x] ErrorBoundary still catches truly unexpected rendering errors
