### PR TITLE
Lazy-load criterion studies in verification UI

### DIFF
--- a/src/api/criterion.ts
+++ b/src/api/criterion.ts
@@ -1,5 +1,5 @@
 import { fetchGearbox } from './utils'
-import { Criterion } from '../model'
+import { Criterion, Study } from '../model'
 
 export function getCriteriaNotExistInMatchForm(): Promise<Criterion[]> {
   return fetchGearbox('/gearbox/criteria-not-exist-in-match-form')
@@ -21,4 +21,10 @@ export function getCriteria(include_studies?: boolean): Promise<Criterion[]> {
   return fetchGearbox(url)
     .then((res) => res.json() as Promise<{ results: Criterion[] }>)
     .then((res) => res.results)
+}
+
+export function getCriterionStudies(criterionId: number): Promise<Study[]> {
+  return fetchGearbox(`/gearbox/criterion/${criterionId}/studies`).then(
+    (res) => res.json() as Promise<Study[]>
+  )
 }

--- a/src/components/CriteriaAnnotationVerification.tsx
+++ b/src/components/CriteriaAnnotationVerification.tsx
@@ -24,6 +24,7 @@ import DropdownSection from './DropdownSection'
 import TrialCard from './TrialCard'
 import { Info } from 'react-feather'
 import { useModal } from '../hooks/useModal'
+import { getCriterionStudies } from '../api/criterion'
 type Status = CriterionStaging['criterion_adjudication_status']
 
 export function CriteriaAnnotationVerification({
@@ -365,11 +366,26 @@ export function CriteriaAnnotationVerification({
     label: c.code,
   }))
 
-  const associatedStudies: Study[] =
-    criteria.find((c) => c.id === stagingCriterion.criterion_id)?.studies || []
-
   const [showModal, openModal, closeModal] = useModal()
   const matchInfoId = `match-info-${stagingCriterion.id}`
+
+  const criterionId = stagingCriterion.criterion_id
+  const [lazyStudies, setLazyStudies] = useState<Study[] | null>(null)
+  const [studiesLoading, setStudiesLoading] = useState(false)
+  const [studiesSectionOpen, setStudiesSectionOpen] = useState(false)
+
+  const handleStudiesExpand = (next: boolean) => {
+    setStudiesSectionOpen(next)
+    if (next && criterionId && lazyStudies === null && !studiesLoading) {
+      setStudiesLoading(true)
+      getCriterionStudies(criterionId)
+        .then((studies) => setLazyStudies(studies))
+        .catch(() => setLazyStudies([]))
+        .finally(() => setStudiesLoading(false))
+    }
+  }
+
+  const studyList = lazyStudies ?? []
 
   return (
     <div className="my-4 p-4 border border-gray-400">
@@ -626,13 +642,20 @@ export function CriteriaAnnotationVerification({
           }}
         />
       )}
-      {associatedStudies.length > 0 && (
+      {criterionId && (
         <DropdownSection
-          name={`Associated Studies (${associatedStudies.length})`}
-          isCollapsedAtStart={true}
+          name={
+            studiesLoading
+              ? 'Associated Studies (loading…)'
+              : lazyStudies !== null
+              ? `Associated Studies (${studyList.length})`
+              : 'Associated Studies'
+          }
+          isOpen={studiesSectionOpen}
+          onToggle={handleStudiesExpand}
         >
           <div className="mx-2">
-            {associatedStudies.map((study) => (
+            {studyList.map((study) => (
               <TrialCard study={study} key={study.id} />
             ))}
           </div>


### PR DESCRIPTION
Add API helper getCriterionStudies and update CriteriaAnnotationVerification to fetch associated studies on demand. The component now imports getCriterionStudies, tracks lazyStudies, loading and open state, and fetches studies when the "Associated Studies" section is expanded. The dropdown label reflects loading/count state and TrialCard list is rendered from the lazy-loaded studies instead of relying on an eager criteria.studies property. This reduces initial payload and improves UI responsiveness.