### PR TITLE
Use gearbox-middleware API endpoints

### DIFF
--- a/src/api/eligibilityCriteria.ts
+++ b/src/api/eligibilityCriteria.ts
@@ -4,7 +4,7 @@ import { fetchGearbox, readCache, writeCache } from './utils'
 const SESSION_STORAGE_KEY = 'gearbox:eligibility-criteria'
 
 export function getEligibilityCriteriaFromApi() {
-  return fetchGearbox('/gearbox/eligibility-criteria')
+  return fetchGearbox('/gearbox-middleware/eligibility-criteria')
     .then((res) => res.json())
     .then(fetch)
     .then((res) => res.json() as Promise<EligibilityCriterion[]>)

--- a/src/api/importantQuestionsConfig.ts
+++ b/src/api/importantQuestionsConfig.ts
@@ -2,7 +2,7 @@ import { ImportantQuestionConfig } from '../model'
 import { fetchGearbox } from './utils'
 
 export function getImportantQuestionsConfig() {
-  return fetchGearbox('/gearbox/important-questions')
+  return fetchGearbox('/gearbox-middleware/important-questions')
     .then((res) => {
       if (!res.ok) {
         throw new Error('Failed to get important questions config s3 url.')

--- a/src/api/matchConditions.ts
+++ b/src/api/matchConditions.ts
@@ -7,7 +7,7 @@ export function getMatchConditions() {
   const cache = readCache<MatchCondition[]>(SESSION_STORAGE_KEY)
   if (cache !== null) return Promise.resolve(cache)
 
-  return fetchGearbox('/gearbox/match-conditions')
+  return fetchGearbox('/gearbox-middleware/match-conditions')
     .then((res) => res.json())
     .then(fetch)
     .then((res) => res.json() as Promise<MatchCondition[]>)

--- a/src/api/matchFormConfig.ts
+++ b/src/api/matchFormConfig.ts
@@ -17,7 +17,7 @@ function sortDiagnosisOptions(matchForm: MatchFormConfig): MatchFormConfig {
 }
 
 export function getMatchFormConfig() {
-  return fetchGearbox('/gearbox/match-form')
+  return fetchGearbox('/gearbox-middleware/match-form')
     .then((res) => res.json())
     .then(fetch)
     .then((res) => res.json() as Promise<MatchFormConfig>)

--- a/src/api/studies.ts
+++ b/src/api/studies.ts
@@ -4,7 +4,7 @@ import { fetchGearbox, readCache, writeCache } from './utils'
 const SESSION_STORAGE_KEY = 'gearbox:studies'
 
 export function getStudiesFromApi() {
-  return fetchGearbox('/gearbox/studies')
+  return fetchGearbox('/gearbox-middleware/studies')
     .then((res) => res.json())
     .then(fetch)
     .then((res) => res.json() as Promise<{ version: string; studies: Study[] }>)


### PR DESCRIPTION
Replace direct '/gearbox/...' endpoints with '/gearbox-middleware/...' across API modules (eligibilityCriteria, importantQuestionsConfig, matchConditions, matchFormConfig, studies). Routes now point to the middleware service for fetching JSON; no other logic or caching behavior was changed.

This PR needs to be merged before this one: https://github.com/chicagopcdc/gearbox-middleware/pull/33