### PR TITLE
GEAR-610 fix(ui): sync trial search and rename potential matches

### DIFF
--- a/src/components/AdminStudySelector.test.tsx
+++ b/src/components/AdminStudySelector.test.tsx
@@ -1,5 +1,6 @@
-import { render } from '@testing-library/react'
+import { render, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { useState } from 'react'
 import type { StudyVersionAdjudication } from '../model'
 import { AdminStudySelector } from './AdminStudySelector'
 
@@ -57,7 +58,7 @@ test('groups studies by workflow status and keeps published studies read-only', 
     getByLabelText('Select a Study'),
     String(needsInput.eligibility_criteria_id)
   )
-  expect(onChange).toHaveBeenCalledTimes(1)
+  expect(onChange).toHaveBeenCalledWith(needsInput.eligibility_criteria_id)
 })
 
 test('searches trials by code or title and clears the filter', async () => {
@@ -129,4 +130,47 @@ test('shows an empty state and supports keyboard handoff to the trial list', asy
   await user.clear(search)
   await user.type(search, '{ArrowDown}')
   expect(getByLabelText('Select a Study')).toHaveFocus()
+})
+
+test('clears the selected study when the search filters it out', async () => {
+  const user = userEvent.setup()
+  const needsInput = studyVersion(1, 'TRIAL-1', 'IN_PROCESS')
+  const otherStudy = studyVersion(2, 'TRIAL-2', 'IN_PROCESS')
+
+  function ControlledSelector() {
+    const [value, setValue] = useState<number | ''>('')
+    return (
+      <>
+        <AdminStudySelector
+          groups={{
+            needsInput: [needsInput, otherStudy],
+            published: [],
+          }}
+          label="Select a Study"
+          name="studyVersion"
+          value={value}
+          onChange={setValue}
+        />
+        <output aria-label="Selected study">{value || 'None'}</output>
+      </>
+    )
+  }
+
+  const { getByLabelText, getByRole } = render(<ControlledSelector />)
+  await user.selectOptions(
+    getByLabelText('Select a Study'),
+    String(needsInput.eligibility_criteria_id)
+  )
+  expect(getByRole('status', { name: 'Selected study' })).toHaveTextContent(
+    String(needsInput.eligibility_criteria_id)
+  )
+
+  await user.type(getByRole('searchbox', { name: 'Search trials' }), 'TRIAL-2')
+
+  await waitFor(() =>
+    expect(getByRole('status', { name: 'Selected study' })).toHaveTextContent(
+      'None'
+    )
+  )
+  expect(getByLabelText('Select a Study')).toHaveValue('')
 })

--- a/src/components/AdminStudySelector.tsx
+++ b/src/components/AdminStudySelector.tsx
@@ -7,7 +7,7 @@ type AdminStudySelectorProps = {
   label: string
   name: string
   value: number | ''
-  onChange: React.ChangeEventHandler<HTMLSelectElement>
+  onChange: (value: number | '') => void
 }
 
 function studyLabel(code: string, name: string): string {
@@ -50,6 +50,24 @@ export function AdminStudySelector({
   )
   const resultCount =
     filteredGroups.needsInput.length + filteredGroups.published.length
+  const updateSearchQuery = (nextSearchQuery: string) => {
+    setSearchQuery(nextSearchQuery)
+    if (value === '') return
+
+    const selectedStudy = [...groups.needsInput, ...groups.published].find(
+      (studyVersion) => studyVersion.eligibility_criteria_id === value
+    )
+    if (
+      !selectedStudy ||
+      !matchesSearch(
+        selectedStudy.study.code,
+        selectedStudy.study.name,
+        nextSearchQuery
+      )
+    ) {
+      onChange('')
+    }
+  }
 
   return (
     <section aria-label="Study status" className="space-y-2">
@@ -75,7 +93,7 @@ export function AdminStudySelector({
           <input
             aria-label="Search trials"
             className="w-full rounded-none border border-b-0 border-solid border-black py-2 pl-9 pr-9"
-            onChange={(event) => setSearchQuery(event.target.value)}
+            onChange={(event) => updateSearchQuery(event.target.value)}
             onKeyDown={(event) => {
               if (event.key === 'ArrowDown') {
                 event.preventDefault()
@@ -90,7 +108,7 @@ export function AdminStudySelector({
             <button
               aria-label="Clear trial search"
               className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-600 hover:text-black"
-              onClick={() => setSearchQuery('')}
+              onClick={() => updateSearchQuery('')}
               title="Clear trial search"
               type="button"
             >
@@ -105,7 +123,7 @@ export function AdminStudySelector({
           ref={selectRef}
           value={value}
           onChange={(event) => {
-            onChange(event)
+            onChange(event.target.value ? +event.target.value : '')
             setSearchQuery('')
           }}
         >

--- a/src/components/MatchResult.test.tsx
+++ b/src/components/MatchResult.test.tsx
@@ -1,0 +1,23 @@
+import { render } from '@testing-library/react'
+import MatchResult from './MatchResult'
+
+test('labels undetermined trial results as potential matches', () => {
+  const { getByRole, getByText, queryByText } = render(
+    <MatchResult
+      matchDetails={{}}
+      matchGroups={{ matched: [], undetermined: [], unmatched: [] }}
+      studies={[]}
+      matchCounts={{ matched: 0, undetermined: 12, unmatched: 0 }}
+      pageSize={10}
+      matchPages={{ matched: 1, undetermined: 1, unmatched: 1 }}
+      onChangeMatchPage={jest.fn()}
+      onSetMatchPage={jest.fn()}
+    />
+  )
+
+  expect(
+    getByRole('heading', { name: 'Potential Match (12)' })
+  ).toBeInTheDocument()
+  expect(getByText('Potential Match: 1-10 of 12')).toBeInTheDocument()
+  expect(queryByText(/Undetermined/i)).not.toBeInTheDocument()
+})

--- a/src/components/MatchResult.tsx
+++ b/src/components/MatchResult.tsx
@@ -164,10 +164,10 @@ function MatchResult({
         </div>
       </DropdownSection>
 
-      <DropdownSection name={`Undetermined (${matchCounts.undetermined})`}>
+      <DropdownSection name={`Potential Match (${matchCounts.undetermined})`}>
         <div className="mx-2">
           {renderTrialCards(undetermined)}
-          {renderPagination('undetermined', 'Undetermined')}
+          {renderPagination('undetermined', 'Potential Match')}
         </div>
       </DropdownSection>
 

--- a/src/pages/CriteriaAnnotationVerificationPage.tsx
+++ b/src/pages/CriteriaAnnotationVerificationPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
 import {
   AdminStudyVersionGroups,
   getAdminStudyVersionGroups,
@@ -51,6 +51,7 @@ export function CriteriaAnnotationVerificationPage() {
   const [loadingStatus, setLoadingStatus] = useState<ApiStatus>('not started')
   const [showModal, openModal, closeModal] = useModal()
   const [rawCriterion, setRawCriterion] = useState<RawCriterion | null>(null)
+  const requestedEligibilityCriteriaId = useRef<number | ''>('')
 
   const { topRef, createScrollItemRef, scrollToTop, showBackToTop } =
     useManageItemScrollPosition<number>({
@@ -104,15 +105,23 @@ export function CriteriaAnnotationVerificationPage() {
     loadPage()
   }, [])
 
-  const onStudyChanged = (event: React.ChangeEvent<HTMLSelectElement>) => {
-    const ebcId = +event.target.value
+  const onStudyChanged = (ebcId: number | '') => {
+    requestedEligibilityCriteriaId.current = ebcId
+    setEligibilityCriteriaId(ebcId)
+    if (ebcId === '') {
+      setStagingCriteria([])
+      setRawCriterion(null)
+      return
+    }
+
     Promise.all([getCriterionStaging(ebcId), getRawCriterion(ebcId)])
       .then(([sc, rc]) => {
+        if (requestedEligibilityCriteriaId.current !== ebcId) return
         setStagingCriteria(sc)
         setRawCriterion(rc)
-        setEligibilityCriteriaId(ebcId)
       })
       .catch(() => {
+        if (requestedEligibilityCriteriaId.current !== ebcId) return
         setStagingCriteria([])
         setRawCriterion(null)
       })

--- a/src/pages/CriteriaValueAssignmentPage.tsx
+++ b/src/pages/CriteriaValueAssignmentPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import {
   ApiStatus,
   CriteriaValue,
@@ -32,6 +32,7 @@ export function CriteriaValueAssignmentPage() {
   const [numericValues, setNumericValues] = useState<CriteriaValue[]>([])
   const [units, setUnits] = useState<Unit[]>([])
   const [loadingStatus, setLoadingStatus] = useState<ApiStatus>('not started')
+  const requestedEligibilityCriteriaId = useRef<number | ''>('')
 
   const loadPage = () => {
     Promise.all([
@@ -53,20 +54,31 @@ export function CriteriaValueAssignmentPage() {
       })
   }
 
-  const onStudyChanged = (event: React.ChangeEvent<HTMLSelectElement>) => {
-    const eligibilityCriteriaId = +event.target.value
+  const onStudyChanged = (eligibilityCriteriaId: number | '') => {
+    requestedEligibilityCriteriaId.current = eligibilityCriteriaId
     setEligibilityCriteriaId(eligibilityCriteriaId)
+    if (eligibilityCriteriaId === '') {
+      setActiveStagingCriteria([])
+      return
+    }
+
     Promise.all([
       getCriterionStaging(eligibilityCriteriaId),
       getElCriteriaHasCriterionsByElId(eligibilityCriteriaId),
     ])
       .then(([stagingCriteria]) => {
+        if (requestedEligibilityCriteriaId.current !== eligibilityCriteriaId)
+          return
         const activeStagingCriteria = stagingCriteria.filter(
           (sc) => sc.criterion_adjudication_status === 'ACTIVE'
         )
         setActiveStagingCriteria(activeStagingCriteria)
       })
-      .catch(() => setActiveStagingCriteria([]))
+      .catch(() => {
+        if (requestedEligibilityCriteriaId.current !== eligibilityCriteriaId)
+          return
+        setActiveStagingCriteria([])
+      })
   }
 
   useEffect(() => {


### PR DESCRIPTION
Follow-up to #375.

## Summary
- Clear the selected admin study and associated page data when a search filters that study out.
- Ignore late API responses for a previously selected study.
- Rename the user-facing Undetermined clinical-trial group to Potential Match while preserving the backend `undetermined` key.
- Add regression tests for selection synchronization and match-result labels.

## Testing
- `CI=true NODE_OPTIONS=--openssl-legacy-provider npm test -- --watchAll=false --runInBand src/components/AdminStudySelector.test.tsx src/components/MatchResult.test.tsx src/api/studyAdjudication.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `NODE_OPTIONS=--openssl-legacy-provider npm run build` (passes with existing unrelated lint warnings)