### PR TITLE
Enhanced gearbox trial matching UI (GSoC 2026)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import {
 import Layout from './Layout'
 import AboutPage from './pages/AboutPage'
 import MatchingPage from './pages/MatchingPage'
+import EnhancedMatchingPage from './pages/EnhancedMatchingPage'
 import LandingPage from './pages/LandingPage'
 import LoginPage from './pages/LoginPage'
 import RegisterPage from './pages/RegisterPage'
@@ -71,6 +72,8 @@ function App() {
                 <Navigate to="/register" replace />
               ) : auth.hasDocsToBeReviewed ? (
                 <Navigate to="/document-review" replace />
+              ) : process.env.REACT_APP_ENHANCED_UI === 'true' ? (
+                <EnhancedMatchingPage {...gearboxData} />
               ) : (
                 <MatchingPage {...gearboxData} />
               )

--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -32,8 +32,9 @@ function Layout({
   const isLoginPage = location.pathname.toLowerCase() === '/login'
   const isLLSLandingPage = location.pathname.toLowerCase() === '/lls'
   const isHomeLandingPage = isHomePage && !isAuthenticated
+  const isEnhancedUI = process.env.REACT_APP_ENHANCED_UI === 'true'
   const mainClassName =
-    isHomeLandingPage || isLLSLandingPage
+    isHomeLandingPage || isLLSLandingPage || (isHomePage && isEnhancedUI)
       ? ''
       : 'flex-1 lg:w-screen-lg mx-4 lg:mx-auto my-12'
   const isHomeMatchingPage = isHomePage && isAuthenticated

--- a/src/components/enhanced/CategorySidebar.tsx
+++ b/src/components/enhanced/CategorySidebar.tsx
@@ -1,0 +1,43 @@
+import type { CategorySummary } from './types'
+
+type CategorySidebarProps = {
+  categories: CategorySummary[]
+  activeCategoryId: number | null
+  onSelectCategory: (id: number) => void
+}
+
+function CategorySidebar({
+  categories,
+  activeCategoryId,
+  onSelectCategory,
+}: CategorySidebarProps) {
+  return (
+    <nav>
+      <div className="text-xs uppercase tracking-wider text-gray-500 px-4 py-3 font-medium">
+        Categories
+      </div>
+      <ul>
+        {categories.map((category) => {
+          const isActive = category.id === activeCategoryId
+          return (
+            <li key={category.id}>
+              <button
+                onClick={() => onSelectCategory(category.id)}
+                aria-current={isActive ? 'page' : undefined}
+                className={`w-full text-left px-4 py-2 text-sm ${
+                  isActive
+                    ? 'border-l-4 border-primary bg-red-100 text-primary font-medium'
+                    : 'border-l-4 border-transparent hover:bg-gray-100'
+                }`}
+              >
+                {category.name}
+              </button>
+            </li>
+          )
+        })}
+      </ul>
+    </nav>
+  )
+}
+
+export default CategorySidebar

--- a/src/components/enhanced/EnhancedMatchForm.tsx
+++ b/src/components/enhanced/EnhancedMatchForm.tsx
@@ -1,0 +1,213 @@
+import type React from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import DropdownSection from '../DropdownSection'
+import FieldWrapper from '../FieldWrapper'
+import Field from '../Inputs/Field'
+import {
+  clearShowIfField,
+  getDefaultValues,
+  getIsFieldShowing,
+} from '../../utils'
+import type { MatchFormProps } from '../MatchForm'
+import type { MatchFormValues, MatchFormFieldConfig } from '../../model'
+
+type EnhancedMatchFormProps = MatchFormProps & {
+  activeCategoryId: number | null
+  onActiveCategoryChange: (id: number | null) => void
+  registerScrollTarget: (id: number) => (el: HTMLElement | null) => void
+  highlightedFieldId: number | null
+}
+
+function EnhancedMatchForm({
+  config,
+  matchInput,
+  isFilterActive,
+  updateMatchInput,
+  setIsUpdating,
+  importantQuestionsConfig, // eslint-disable-line @typescript-eslint/no-unused-vars
+  locationFilterSection,
+  activeCategoryId,
+  onActiveCategoryChange,
+  registerScrollTarget,
+  highlightedFieldId,
+}: EnhancedMatchFormProps) {
+  const [values, setValues] = useState(getDefaultValues(config))
+  useEffect(() => setValues({ ...matchInput }), [matchInput])
+
+  const formEl = useRef<HTMLFormElement>(null)
+  const timeoutRef = useRef<NodeJS.Timeout | undefined>()
+  const observerRef = useRef<IntersectionObserver | null>(null)
+  const sectionHeaderRefs = useRef<Map<number, HTMLElement>>(new Map())
+  const suspendObserverRef = useRef(false)
+
+  const handleChange =
+    (fieldType: MatchFormFieldConfig['type']) =>
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      if (fieldType === 'checkbox' || fieldType === 'multiselect') {
+        return
+      }
+      const { name, value } = e.target
+      const isNumberValue = fieldType === 'select' || fieldType === 'radio'
+      const isEmptyValue = !value
+      const newValues: MatchFormValues = {
+        ...values,
+        [name]: isEmptyValue ? undefined : isNumberValue ? +value : value,
+      }
+      setValues(newValues)
+
+      if (timeoutRef.current !== undefined) clearTimeout(timeoutRef.current)
+
+      if (formEl?.current?.reportValidity()) {
+        setIsUpdating(true)
+        timeoutRef.current = setTimeout(() => {
+          updateMatchInput(clearShowIfField(config, newValues))
+          setIsUpdating(false)
+          clearTimeout(timeoutRef.current)
+        }, 1000)
+      } else setIsUpdating(false)
+    }
+
+  useEffect(() => {
+    observerRef.current = new IntersectionObserver(
+      (entries) => {
+        if (suspendObserverRef.current) return
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            const groupId = Number(entry.target.getAttribute('data-group-id'))
+            if (!isNaN(groupId)) {
+              onActiveCategoryChange(groupId)
+            }
+          }
+        }
+      },
+      { rootMargin: '-10% 0px -80% 0px', threshold: 0 }
+    )
+
+    sectionHeaderRefs.current.forEach((el) => {
+      if (observerRef.current) {
+        observerRef.current.observe(el)
+      }
+    })
+
+    return () => {
+      if (observerRef.current) {
+        observerRef.current.disconnect()
+      }
+    }
+  }, [onActiveCategoryChange])
+
+  const registerSectionHeader =
+    (groupId: number) => (el: HTMLElement | null) => {
+      if (el) {
+        sectionHeaderRefs.current.set(groupId, el)
+        if (observerRef.current) {
+          observerRef.current.observe(el)
+        }
+      } else {
+        const existing = sectionHeaderRefs.current.get(groupId)
+        if (existing && observerRef.current) {
+          observerRef.current.unobserve(existing)
+        }
+        sectionHeaderRefs.current.delete(groupId)
+      }
+    }
+
+  const groupOpenState = useMemo(() => {
+    const state: Record<number, boolean> = {}
+    config.groups.forEach((group) => {
+      state[group.id] = group.id === activeCategoryId
+    })
+    return state
+  }, [activeCategoryId, config.groups])
+
+  const handleToggle = (groupId: number) => (next: boolean) => {
+    suspendObserverRef.current = true
+    onActiveCategoryChange(next ? groupId : null)
+    setTimeout(() => {
+      suspendObserverRef.current = false
+    }, 500)
+  }
+
+  useEffect(() => {
+    if (activeCategoryId !== null) {
+      suspendObserverRef.current = true
+      setTimeout(() => {
+        suspendObserverRef.current = false
+      }, 500)
+    }
+  }, [activeCategoryId])
+
+  return (
+    <form ref={formEl}>
+      {locationFilterSection && (
+        <DropdownSection
+          backgroundColor="bg-white"
+          name="Location Filter (Optional)"
+          isCollapsedAtStart={true}
+        >
+          {locationFilterSection}
+        </DropdownSection>
+      )}
+      {config.groups.map((group) => (
+        <div
+          key={group.id}
+          ref={registerSectionHeader(group.id)}
+          data-group-id={group.id}
+        >
+          <DropdownSection
+            id={`category-${group.id}`}
+            backgroundColor="bg-white"
+            name={group.name || 'General'}
+            isOpen={groupOpenState[group.id]}
+            onToggle={handleToggle(group.id)}
+          >
+            {config.fields.map(
+              ({
+                id,
+                groupId,
+                defaultValue, // eslint-disable-line @typescript-eslint/no-unused-vars
+                relevant,
+                showIf,
+                ...fieldConfig
+              }) => {
+                if (groupId !== group.id) return null
+
+                const isFieldShowing =
+                  (!isFilterActive || relevant) &&
+                  (showIf === undefined ||
+                    getIsFieldShowing(showIf, config, values))
+
+                const isHighlighted = highlightedFieldId === id
+                return (
+                  <FieldWrapper key={id} isShowing={isFieldShowing}>
+                    <div
+                      ref={registerScrollTarget(id)}
+                      data-field-id={id}
+                      className={
+                        isHighlighted
+                          ? 'border-primary ring-2 ring-red-200 transition-all duration-300'
+                          : ''
+                      }
+                    >
+                      <Field
+                        config={{
+                          ...fieldConfig,
+                          name: String(id),
+                          disabled: !relevant,
+                        }}
+                        value={values[id]}
+                        onChange={handleChange(fieldConfig.type)}
+                      />
+                    </div>
+                  </FieldWrapper>
+                )
+              }
+            )}
+          </DropdownSection>
+        </div>
+      ))}
+    </form>
+  )
+}
+
+export default EnhancedMatchForm

--- a/src/components/enhanced/QuickSelect.tsx
+++ b/src/components/enhanced/QuickSelect.tsx
@@ -1,0 +1,41 @@
+import type { MatchFormFieldConfig, ImportantQuestionConfig } from '../../model'
+
+type QuickSelectProps = {
+  fields: MatchFormFieldConfig[]
+  importantQuestionsConfig: ImportantQuestionConfig
+  onSelectField: (id: number) => void
+}
+
+function QuickSelect({
+  fields,
+  importantQuestionsConfig,
+  onSelectField,
+}: QuickSelectProps) {
+  const importantFields = fields.filter((field) =>
+    importantQuestionsConfig.groups.some(
+      (importantGroup) => importantGroup.name === field.name
+    )
+  )
+
+  if (importantFields.length === 0) return null
+
+  return (
+    <div>
+      <h3 className="text-sm font-medium mb-2">Quick Select</h3>
+      <div className="flex flex-wrap gap-2">
+        {importantFields.map((field) => (
+          <button
+            key={field.id}
+            type="button"
+            onClick={() => onSelectField(field.id)}
+            className="border border-gray-300 bg-white px-3 py-1 text-sm hover:bg-gray-100"
+          >
+            {field.name}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default QuickSelect

--- a/src/components/enhanced/README.md
+++ b/src/components/enhanced/README.md
@@ -1,0 +1,46 @@
+# Enhanced Matching UI
+
+Google Summer of Code 2026 — Data for the Common Good
+Contributor: Manjula Kudapa
+
+The GEARBOx matching form presents clinicians with every trial-related question in a single scrolling column. Finding the fields relevant to a particular patient means scrolling past hundreds of questions that don't apply, which slows the matching process and increases the risk of incomplete data entry.
+
+This is a three-panel alternative: category navigation on the left, a searchable form in the centre, and live trial results on the right. Clinicians can search for a field by name and jump straight to it, or browse directly to the category they need.
+
+## The three panels
+
+**Left sidebar (desktop only):** Category navigation. Lists the five form categories (Demographics, Disease, Treatment and Exposure, Organ Function, Biomarkers). Clicking a category expands and scrolls to its section in the center panel. The active category highlights as the user scrolls through the form.
+
+**Center panel:** Patient information form. Contains the search bar, quick-select buttons for important fields, selected values chips, and the accordion form sections grouped by category. Each section expands when its category is active. Form behavior matches the original MatchForm: 1000ms debounce on changes, same validation, same API payloads, same showIf logic.
+
+**Right panel (desktop only):** Live trial results. Displays Matched, Potential Match, and Unmatched trials with server-side pagination (four trials per page per group). Updates in response to form changes. On mobile, the sidebar becomes a horizontal strip and the center/right panels switch via Patient Info / Open Trials buttons.
+
+## Components
+
+**EnhancedMatchingPage.tsx** — top-level page component that wires session state to the three-panel layout, manages scroll position, field selection, and the active category state.
+
+**ThreePanelLayout.tsx** — responsive layout shell; three-column flex on desktop, single-column with tab switcher on mobile.
+
+**CategorySidebar.tsx** — navigation list of category buttons with visual active state and aria-current attribute.
+
+**TypeaheadSearch.tsx** — combobox-pattern search input that filters fields by name, label, or category; returns up to eight results; handles hidden showIf fields by redirecting to their trigger field.
+
+**QuickSelect.tsx** — row of buttons for fields marked in importantQuestionsConfig, allowing fast jumps to commonly used fields.
+
+**EnhancedMatchForm.tsx** — the form itself; renders fields in accordion sections, manages debounced updates, applies field highlighting, tracks scroll position with IntersectionObserver to update active category.
+
+**SelectedValuesBar.tsx** — displays filled fields as dismissible chips showing field label and current value; clearing a chip removes the value and triggers a debounced update.
+
+**ResultsPanel.tsx** — reuses the existing MatchResult component inside a sticky-header wrapper; adds a background color transition during updates and displays blocking criteria for potential matches.
+
+**TrialBlockingCriteria.tsx** — renders missing field names that caused a trial to be marked undetermined.
+
+**getBlockingCriteria.ts** — walks a MatchInfoAlgorithm tree depth-first to extract up to two field names where isMatched is undefined.
+
+**useFieldSearchIndex.ts** — builds a memoized array of SearchableField objects from config and values for the search dropdown; computes visibility and filled state per field.
+
+**types.ts** — shared TypeScript types (SearchableField, CategorySummary) used across enhanced components.
+
+## Data flow
+
+`useMatchingSession` (in src/hooks/) extracts all state and API logic from the original MatchingPage into a reusable hook. It handles fetching match results via getMatchInfo, managing location filters, marking relevant fields, and all user input persistence. EnhancedMatchingPage consumes this hook and passes derived state down to presentational components. Only EnhancedMatchForm holds transient local state (the debounce buffer for form inputs).

--- a/src/components/enhanced/ResultsPanel.tsx
+++ b/src/components/enhanced/ResultsPanel.tsx
@@ -1,0 +1,256 @@
+import DropdownSection from '../DropdownSection'
+import TrialCard from '../TrialCard'
+import TrialMatchInfo from '../TrialMatchInfo'
+import { MapPin } from 'react-feather'
+import { useModal } from '../../hooks/useModal'
+import TrialMapModal from '../TrialMapModal'
+import type {
+  MatchDetails,
+  MatchGroupCounts,
+  MatchGroups,
+  Study,
+} from '../../model'
+import { getBlockingCriteria } from './getBlockingCriteria'
+import TrialBlockingCriteria from './TrialBlockingCriteria'
+
+type MatchGroupKey = keyof MatchGroups
+
+type ResultsPanelProps = {
+  matchDetails: MatchDetails
+  matchGroups: MatchGroups
+  studies: Study[]
+  matchCounts: MatchGroupCounts
+  pageSize: number
+  matchPages: Record<MatchGroupKey, number>
+  onChangeMatchPage: (group: MatchGroupKey, direction: -1 | 1) => void
+  onSetMatchPage: (group: MatchGroupKey, page: number) => void
+  patientValuesByFieldName?: Record<string, unknown>
+  isUpdating: boolean
+}
+
+function ResultsPanel({
+  matchDetails,
+  matchGroups,
+  studies,
+  matchCounts,
+  pageSize,
+  matchPages,
+  onChangeMatchPage,
+  onSetMatchPage,
+  patientValuesByFieldName = {},
+  isUpdating,
+}: ResultsPanelProps) {
+  const [showMap, openMap, closeMap] = useModal()
+  const { matched = [], undetermined = [], unmatched = [] } = matchGroups
+
+  const studyById: { [id: number]: Study } = {}
+  for (const study of studies) studyById[study.id] = study
+
+  function getPageItems(currentPage: number, pageCount: number) {
+    if (pageCount <= 7) {
+      return Array.from({ length: pageCount }, (_, index) => index + 1)
+    }
+
+    const pages = new Set<number>([1, pageCount, currentPage])
+
+    if (currentPage > 1) pages.add(currentPage - 1)
+    if (currentPage < pageCount) pages.add(currentPage + 1)
+
+    if (currentPage <= 3) {
+      pages.add(2)
+      pages.add(3)
+      pages.add(4)
+    }
+
+    if (currentPage >= pageCount - 2) {
+      pages.add(pageCount - 1)
+      pages.add(pageCount - 2)
+      pages.add(pageCount - 3)
+    }
+
+    const sortedPages = Array.from(pages)
+      .filter((page) => page >= 1 && page <= pageCount)
+      .sort((a, b) => a - b)
+
+    const pageItems: Array<number | 'ellipsis'> = []
+
+    sortedPages.forEach((page, index) => {
+      const previousPage = sortedPages[index - 1]
+
+      if (previousPage && page - previousPage > 1) {
+        pageItems.push('ellipsis')
+      }
+
+      pageItems.push(page)
+    })
+
+    return pageItems
+  }
+
+  function renderPagination(group: MatchGroupKey, label: string) {
+    const total = matchCounts[group]
+
+    if (total <= pageSize) return null
+
+    const currentPage = matchPages[group]
+    const pageCount = Math.ceil(total / pageSize)
+    const start = (currentPage - 1) * pageSize + 1
+    const end = Math.min(currentPage * pageSize, total)
+
+    return (
+      <div className="mb-4 mt-2 flex items-center justify-between rounded border border-gray-200 bg-white px-3 py-2 text-sm">
+        <span>
+          {label}: {start}-{end} of {total}
+        </span>
+
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            className="rounded border px-2 py-1 disabled:opacity-50"
+            disabled={currentPage === 1}
+            onClick={() => onChangeMatchPage(group, -1)}
+          >
+            Previous
+          </button>
+
+          <div className="flex items-center gap-1">
+            {getPageItems(currentPage, pageCount).map((pageItem, index) =>
+              pageItem === 'ellipsis' ? (
+                <span key={`ellipsis-${index}`} className="px-1">
+                  ...
+                </span>
+              ) : (
+                <button
+                  key={pageItem}
+                  type="button"
+                  aria-current={pageItem === currentPage ? 'page' : undefined}
+                  className={`rounded border px-2 py-1 ${
+                    pageItem === currentPage ? 'font-bold bg-gray-100' : ''
+                  }`}
+                  disabled={pageItem === currentPage}
+                  onClick={() => onSetMatchPage(group, pageItem)}
+                >
+                  {pageItem}
+                </button>
+              )
+            )}
+          </div>
+
+          <button
+            type="button"
+            className="rounded border px-2 py-1 disabled:opacity-50"
+            disabled={currentPage === pageCount}
+            onClick={() => onChangeMatchPage(group, 1)}
+          >
+            Next
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  function renderTrialCards(ids: number[], overallStatus: boolean | undefined) {
+    return ids.map((id) => {
+      const study = studyById[id]
+
+      if (!study) return null
+
+      return (
+        <TrialCard study={study} key={id}>
+          {matchDetails[id] && (
+            <TrialMatchInfo
+              overallStatus={overallStatus}
+              patientValues={patientValuesByFieldName}
+              study={study}
+              studyMatchInfo={matchDetails[id]}
+            />
+          )}
+        </TrialCard>
+      )
+    })
+  }
+
+  function renderUndeterminedCards() {
+    return undetermined.map((id) => {
+      const study = studyById[id]
+
+      if (!study) return null
+
+      const blockingCriteria = matchDetails[id]
+        ? getBlockingCriteria(matchDetails[id], 2)
+        : []
+
+      return (
+        <div key={id}>
+          <TrialCard study={study}>
+            {matchDetails[id] && (
+              <TrialMatchInfo
+                overallStatus={undefined}
+                patientValues={patientValuesByFieldName}
+                study={study}
+                studyMatchInfo={matchDetails[id]}
+              />
+            )}
+          </TrialCard>
+          <TrialBlockingCriteria criteria={blockingCriteria} />
+        </div>
+      )
+    })
+  }
+
+  return (
+    <div
+      className={`h-full overflow-y-auto transition-colors duration-300 ${
+        isUpdating ? 'bg-gray-100' : 'bg-white'
+      }`}
+    >
+      <div className="sticky top-0 z-10 border-b border-gray-300 bg-white px-6 py-3">
+        <h2 className="text-lg font-bold">Open Trials</h2>
+      </div>
+
+      <div className="p-6">
+        <div className="mb-3 flex justify-end">
+          <button
+            className="flex items-center gap-2 rounded border border-primary px-3 py-2 font-bold text-primary hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-primary"
+            onClick={openMap}
+            type="button"
+          >
+            <MapPin size="1rem" />
+            Map View
+          </button>
+        </div>
+
+        {showMap && (
+          <TrialMapModal
+            closeModal={closeMap}
+            matchGroups={matchGroups}
+            studies={studies}
+          />
+        )}
+
+        <DropdownSection name={`Matched (${matchCounts.matched})`}>
+          <div className="mx-2">
+            {renderTrialCards(matched, true)}
+            {renderPagination('matched', 'Matched')}
+          </div>
+        </DropdownSection>
+
+        <DropdownSection name={`Potential Match (${matchCounts.undetermined})`}>
+          <div className="mx-2">
+            {renderUndeterminedCards()}
+            {renderPagination('undetermined', 'Potential Match')}
+          </div>
+        </DropdownSection>
+
+        <DropdownSection name={`Unmatched (${matchCounts.unmatched})`}>
+          <div className="mx-2">
+            {renderTrialCards(unmatched, false)}
+            {renderPagination('unmatched', 'Unmatched')}
+          </div>
+        </DropdownSection>
+      </div>
+    </div>
+  )
+}
+
+export default ResultsPanel

--- a/src/components/enhanced/SelectedValuesBar.tsx
+++ b/src/components/enhanced/SelectedValuesBar.tsx
@@ -1,0 +1,79 @@
+import { getFieldOptionLabelMap } from '../../utils'
+import type { MatchFormFieldConfig, MatchFormValues } from '../../model'
+
+type SelectedValuesBarProps = {
+  fields: MatchFormFieldConfig[]
+  values: MatchFormValues
+  onClearField: (id: number) => void
+}
+
+function SelectedValuesBar({
+  fields,
+  values,
+  onClearField,
+}: SelectedValuesBarProps) {
+  const fieldOptionLabelMap = getFieldOptionLabelMap(fields)
+
+  const filledFields = fields.filter(
+    (field) => values[field.id] !== undefined && values[field.id] !== ''
+  )
+
+  if (filledFields.length === 0) {
+    return (
+      <div className="border border-gray-300 bg-white">
+        <h3 className="text-sm font-medium px-4 py-2 border-b border-gray-300">
+          Selected Values
+        </h3>
+        <div className="p-4 text-gray-500 text-sm italic">
+          No fields filled yet. Search or select from the form below.
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="border border-gray-300 bg-white">
+      <h3 className="text-sm font-medium px-4 py-2 border-b border-gray-300">
+        Selected Values
+      </h3>
+      <div className="p-4 flex flex-wrap gap-2">
+        {filledFields.map((field) => {
+          const fieldValue = values[field.id]
+          const fieldLabel = field.label || field.name
+
+          let displayValue: string
+          if (
+            field.options &&
+            fieldOptionLabelMap[field.id] &&
+            fieldOptionLabelMap[field.id][fieldValue as number]
+          ) {
+            displayValue = fieldOptionLabelMap[field.id][fieldValue as number]
+          } else {
+            displayValue = String(fieldValue)
+          }
+
+          return (
+            <div
+              key={field.id}
+              className="inline-flex items-center gap-2 bg-gray-200 px-3 py-1 border border-solid border-gray-300"
+            >
+              <span className="text-sm">
+                {fieldLabel}: {displayValue}
+              </span>
+              <button
+                type="button"
+                onClick={() => onClearField(field.id)}
+                className="text-gray-600 hover:text-black font-bold"
+                aria-label={`Clear ${fieldLabel}`}
+              >
+                ×
+              </button>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+export default SelectedValuesBar

--- a/src/components/enhanced/ThreePanelLayout.tsx
+++ b/src/components/enhanced/ThreePanelLayout.tsx
@@ -1,0 +1,65 @@
+import React, { useState } from 'react'
+import useScreenSize from '../../hooks/useScreenSize'
+import Button from '../Inputs/Button'
+
+type ThreePanelLayoutProps = {
+  sidebar: React.ReactNode
+  form: React.ReactNode
+  results: React.ReactNode
+}
+
+function ThreePanelLayout({ sidebar, form, results }: ThreePanelLayoutProps) {
+  const screenSize = useScreenSize()
+  const [view, setView] = useState<'form' | 'result'>('form')
+
+  if (screenSize.smAndDown) {
+    return (
+      <>
+        <div
+          className="flex justify-center sticky top-0 bg-white z-10"
+          style={{
+            minHeight: '2.5rem',
+          }}
+        >
+          <Button
+            size="small"
+            block
+            outline={view !== 'form'}
+            onClick={() => setView('form')}
+          >
+            <div className="py-2">Patient Info</div>
+          </Button>
+          <Button
+            size="small"
+            block
+            outline={view !== 'result'}
+            onClick={() => setView('result')}
+          >
+            Open Trials
+          </Button>
+        </div>
+        <div className="bg-white">{sidebar}</div>
+        <section className={`${view === 'form' ? '' : 'hidden'}`}>
+          {form}
+        </section>
+        <section className={`${view === 'result' ? '' : 'hidden'}`}>
+          {results}
+        </section>
+      </>
+    )
+  }
+
+  return (
+    <div className="flex h-screen bg-white">
+      <aside className="w-56 overflow-y-auto border-r border-gray-300 bg-white">
+        {sidebar}
+      </aside>
+      <main className="flex-1 overflow-y-auto bg-white">{form}</main>
+      <aside className="w-2/5 min-w-[380px] overflow-y-auto border-l border-gray-300 bg-white">
+        {results}
+      </aside>
+    </div>
+  )
+}
+
+export default ThreePanelLayout

--- a/src/components/enhanced/TrialBlockingCriteria.tsx
+++ b/src/components/enhanced/TrialBlockingCriteria.tsx
@@ -1,0 +1,15 @@
+type TrialBlockingCriteriaProps = {
+  criteria: string[]
+}
+
+function TrialBlockingCriteria({ criteria }: TrialBlockingCriteriaProps) {
+  if (criteria.length === 0) return null
+
+  return (
+    <div className="px-4 py-2 text-sm text-gray-600">
+      <span className="text-red-600">⚠</span> Missing: {criteria.join(', ')}
+    </div>
+  )
+}
+
+export default TrialBlockingCriteria

--- a/src/components/enhanced/TypeaheadSearch.tsx
+++ b/src/components/enhanced/TypeaheadSearch.tsx
@@ -1,0 +1,162 @@
+import { useState } from 'react'
+import type { SearchableField } from './types'
+
+type TypeaheadSearchProps = {
+  fields: SearchableField[]
+  onSelectField: (id: number) => void
+}
+
+function TypeaheadSearch({ fields, onSelectField }: TypeaheadSearchProps) {
+  const [query, setQuery] = useState('')
+  const [isOpen, setIsOpen] = useState(false)
+  const [activeIndex, setActiveIndex] = useState(-1)
+
+  const filteredFields = query.trim()
+    ? fields
+        .filter((field) => {
+          const q = query.toLowerCase()
+          return (
+            field.name.toLowerCase().includes(q) ||
+            field.label.toLowerCase().includes(q) ||
+            field.groupName.toLowerCase().includes(q)
+          )
+        })
+        .slice(0, 8)
+    : []
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setQuery(e.target.value)
+    setIsOpen(e.target.value.trim().length > 0)
+    setActiveIndex(0)
+  }
+
+  const handleSelect = (field: SearchableField) => {
+    setQuery('')
+    setIsOpen(false)
+    setActiveIndex(-1)
+    if (field.isHiddenByShowIf && field.triggerFieldId) {
+      onSelectField(field.triggerFieldId)
+    } else {
+      onSelectField(field.id)
+    }
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!isOpen || filteredFields.length === 0) {
+      if (e.key === 'Escape') {
+        setQuery('')
+        setIsOpen(false)
+        setActiveIndex(0)
+      }
+      return
+    }
+
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault()
+        setActiveIndex((prev) =>
+          prev < filteredFields.length - 1 ? prev + 1 : 0
+        )
+        break
+      case 'ArrowUp':
+        e.preventDefault()
+        setActiveIndex((prev) =>
+          prev > 0 ? prev - 1 : filteredFields.length - 1
+        )
+        break
+      case 'Enter':
+        e.preventDefault()
+        if (filteredFields.length > 0) {
+          handleSelect(filteredFields[activeIndex])
+        }
+        break
+      case 'Escape':
+        e.preventDefault()
+        setIsOpen(false)
+        setActiveIndex(0)
+        break
+      case 'Tab':
+        setIsOpen(false)
+        setActiveIndex(0)
+        break
+    }
+  }
+
+  const handleBlur = (e: React.FocusEvent) => {
+    if (!e.currentTarget.contains(e.relatedTarget)) {
+      setIsOpen(false)
+      setActiveIndex(0)
+    }
+  }
+
+  const listboxId = 'typeahead-listbox'
+  const getOptionId = (index: number) => `option-${index}`
+
+  return (
+    <div className="relative" onBlur={handleBlur}>
+      <input
+        type="text"
+        value={query}
+        onChange={handleInputChange}
+        onKeyDown={handleKeyDown}
+        placeholder="Search for conditions (i.e. age, diagnosis, mutations...)"
+        className="rounded-none border border-solid border-black p-1 w-full"
+        role="combobox"
+        aria-expanded={isOpen}
+        aria-controls={listboxId}
+        aria-activedescendant={
+          activeIndex >= 0 ? getOptionId(activeIndex) : undefined
+        }
+        aria-autocomplete="list"
+      />
+      {isOpen && (
+        <ul
+          id={listboxId}
+          role="listbox"
+          className="absolute z-10 w-full bg-white border border-solid border-black mt-1 max-h-80 overflow-y-auto"
+        >
+          {filteredFields.length === 0 ? (
+            <li className="px-4 py-2 text-gray-500 text-sm">
+              No fields found. Try a different term.
+            </li>
+          ) : (
+            <>
+              <li className="px-4 py-2 text-xs font-semibold text-gray-500 uppercase tracking-wide border-b border-gray-300">
+                Fields matching your search
+              </li>
+              {filteredFields.map((field, index) => (
+                <li
+                  key={field.id}
+                  id={getOptionId(index)}
+                  role="option"
+                  aria-selected={index === activeIndex}
+                  onClick={() => handleSelect(field)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault()
+                      handleSelect(field)
+                    }
+                  }}
+                  tabIndex={-1}
+                  className={`px-4 py-2 cursor-pointer border-b border-gray-200 ${
+                    index === activeIndex ? 'bg-gray-100' : 'hover:bg-gray-100'
+                  } ${field.isHiddenByShowIf ? 'text-gray-400' : ''}`}
+                >
+                  <div className="text-sm">{field.name}</div>
+                  <div className="text-xs text-gray-500">
+                    {field.groupName}
+                    {field.isHiddenByShowIf &&
+                      field.triggerFieldLabel &&
+                      ` • Available after ${field.triggerFieldLabel}`}
+                  </div>
+                </li>
+              ))}
+            </>
+          )}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+export default TypeaheadSearch

--- a/src/components/enhanced/getBlockingCriteria.ts
+++ b/src/components/enhanced/getBlockingCriteria.ts
@@ -1,0 +1,34 @@
+import type { MatchInfo, MatchInfoAlgorithm } from '../../model'
+
+const isMatchAlgorithm = (
+  matchInfoOrAlgo: MatchInfo | MatchInfoAlgorithm
+): matchInfoOrAlgo is MatchInfoAlgorithm => {
+  return Object.prototype.hasOwnProperty.call(matchInfoOrAlgo, 'criteria')
+}
+
+export function getBlockingCriteria(
+  matchInfoAlgorithm: MatchInfoAlgorithm,
+  limit = 2
+): string[] {
+  const fieldNames: string[] = []
+  const seen = new Set<string>()
+
+  function walk(node: MatchInfo | MatchInfoAlgorithm) {
+    if (fieldNames.length >= limit) return
+
+    if (isMatchAlgorithm(node)) {
+      for (const criterion of node.criteria) {
+        walk(criterion)
+        if (fieldNames.length >= limit) return
+      }
+    } else {
+      if (node.isMatched === undefined && !seen.has(node.fieldName)) {
+        seen.add(node.fieldName)
+        fieldNames.push(node.fieldName)
+      }
+    }
+  }
+
+  walk(matchInfoAlgorithm)
+  return fieldNames
+}

--- a/src/components/enhanced/types.ts
+++ b/src/components/enhanced/types.ts
@@ -1,0 +1,20 @@
+import type { MatchFormConfig, MatchFormFieldConfig } from '../../model'
+
+export type SearchableField = {
+  id: MatchFormFieldConfig['id']
+  label: string
+  name: string
+  groupId: MatchFormFieldConfig['groupId']
+  groupName: string
+  isHiddenByShowIf: boolean
+  isFilled: boolean
+  triggerFieldId?: number
+  triggerFieldLabel?: string
+}
+
+export type CategorySummary = {
+  id: MatchFormConfig['groups'][number]['id']
+  name: string
+  visibleCount: number
+  filledCount: number
+}

--- a/src/components/enhanced/useFieldSearchIndex.ts
+++ b/src/components/enhanced/useFieldSearchIndex.ts
@@ -1,0 +1,53 @@
+import { useMemo } from 'react'
+import type { MatchFormConfig, MatchFormValues } from '../../model'
+import { getIsFieldShowing } from '../../utils'
+import type { SearchableField } from './types'
+
+export function useFieldSearchIndex(
+  config: MatchFormConfig,
+  values: MatchFormValues,
+  isFilterActive: boolean
+): SearchableField[] {
+  return useMemo(() => {
+    const groupMap = new Map(config.groups.map((g) => [g.id, g.name]))
+    const fieldMap = new Map(config.fields.map((f) => [f.id, f]))
+
+    return config.fields
+      .filter((field) => !isFilterActive || field.relevant)
+      .map((field) => {
+        const isHiddenByShowIf =
+          field.showIf !== undefined &&
+          !getIsFieldShowing(field.showIf, config, values)
+
+        const isFilled =
+          values[field.id] !== undefined && values[field.id] !== ''
+
+        let triggerFieldId: number | undefined
+        let triggerFieldLabel: string | undefined
+
+        if (
+          isHiddenByShowIf &&
+          field.showIf &&
+          field.showIf.criteria.length > 0
+        ) {
+          triggerFieldId = field.showIf.criteria[0].id
+          const triggerField = fieldMap.get(triggerFieldId)
+          if (triggerField) {
+            triggerFieldLabel = triggerField.label || triggerField.name
+          }
+        }
+
+        return {
+          id: field.id,
+          label: field.label || field.name,
+          name: field.name,
+          groupId: field.groupId,
+          groupName: groupMap.get(field.groupId) || 'General',
+          isHiddenByShowIf,
+          isFilled,
+          triggerFieldId,
+          triggerFieldLabel,
+        }
+      })
+  }, [config, values, isFilterActive])
+}

--- a/src/hooks/useMatchingSession.ts
+++ b/src/hooks/useMatchingSession.ts
@@ -1,0 +1,321 @@
+import { useEffect, useState } from 'react'
+import type { MatchingPageProps } from '../pages/MatchingPage'
+import {
+  MatchDetails,
+  MatchFormFieldConfig,
+  MatchFormValues,
+  MatchGroupCounts,
+  MatchGroups,
+  UserInputUi,
+} from '../model'
+import { getDefaultValues, markRelevantMatchFields } from '../utils'
+import { getMatchInfo } from '../api/middleware'
+import {
+  getAllUserInput,
+  getLatestUserInput,
+  postUserInput,
+} from '../api/userInput'
+import { useLocationFilter } from './useLocationFilter'
+
+const MATCH_PAGE_SIZE = 4
+
+type MatchGroupKey = keyof MatchGroups
+
+const INITIAL_MATCH_PAGES: Record<MatchGroupKey, number> = {
+  matched: 1,
+  unmatched: 1,
+  undetermined: 1,
+}
+
+const INITIAL_MATCH_COUNTS: MatchGroupCounts = {
+  matched: 0,
+  unmatched: 0,
+  undetermined: 0,
+}
+
+export function useMatchingSession({ action, state }: MatchingPageProps) {
+  const { fetchAll } = action
+  const { conditions, config, criteria, studies } = state
+
+  const [isUpdating, setIsUpdating] = useState(false)
+  const [isFilterActive, setIsFilterActive] = useState(true)
+  const [matchDetails, setMatchDetails] = useState<MatchDetails>(
+    {} as MatchDetails
+  )
+  const [matchGroups, setMatchGroups] = useState<MatchGroups>({
+    matched: [],
+    unmatched: [],
+    undetermined: [],
+  })
+
+  const [allUnmatchedStudyIds, setAllUnmatchedStudyIds] = useState<number[]>([])
+  const [matchCounts, setMatchCounts] =
+    useState<MatchGroupCounts>(INITIAL_MATCH_COUNTS)
+
+  const [matchPages, setMatchPages] =
+    useState<Record<MatchGroupKey, number>>(INITIAL_MATCH_PAGES)
+
+  const [allUserInput, setAllUserInput] = useState<UserInputUi[]>([])
+  const [currentUserInput, setCurrentUserInput] = useState<UserInputUi>({
+    values: {},
+  })
+  const [markedFields, setMarkedFields] = useState<MatchFormFieldConfig[]>([])
+  const [showAllUserInput, setShowAllUserInput] = useState<boolean>(true)
+  const [errorDetail, setErrorDetail] = useState<string | null>(null)
+  const [triedBrowserLocation, setTriedBrowserLocation] =
+    useState<boolean>(false)
+
+  const {
+    filter: locationFilter,
+    setFilter: setLocationFilter,
+    params: locationParams,
+    error: locationError,
+    apply: applyLocationFilter,
+    clear: clearLocationFilter,
+    isActive: isLocationActive,
+    isResolving: isLocationResolving,
+  } = useLocationFilter()
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        if (process.env.ENABLE_PHI) {
+          const allUserInput = await getAllUserInput()
+          setAllUserInput(allUserInput)
+          setShowAllUserInput(true)
+        } else {
+          const latestUserInput = await getLatestUserInput()
+          setCurrentUserInput(latestUserInput)
+          setShowAllUserInput(false)
+        }
+      } catch (e) {
+        console.error(e)
+      }
+    }
+    fetchData()
+  }, [])
+
+  useEffect(() => {
+    setMatchPages(INITIAL_MATCH_PAGES)
+  }, [currentUserInput.values, locationParams])
+
+  useEffect(() => {
+    let ignore = false
+
+    const matchInput = currentUserInput.values
+
+    const locationForApi = locationParams
+      ? {
+          lat: locationParams.lat,
+          lon: locationParams.lon,
+          range: locationParams.range,
+          unit: locationParams.unit,
+        }
+      : undefined
+
+    getMatchInfo(matchInput, locationForApi, {
+      offsetMatched: (matchPages.matched - 1) * MATCH_PAGE_SIZE,
+      limitMatched: MATCH_PAGE_SIZE,
+
+      offsetUnmatched: (matchPages.unmatched - 1) * MATCH_PAGE_SIZE,
+      limitUnmatched: MATCH_PAGE_SIZE,
+
+      offsetUndetermined: (matchPages.undetermined - 1) * MATCH_PAGE_SIZE,
+      limitUndetermined: MATCH_PAGE_SIZE,
+    })
+      .then(({ groups, match_details, total_counts, all_unmatched }) => {
+        if (ignore) return
+
+        setMatchGroups(groups)
+        setMatchDetails(match_details)
+        setMatchCounts(total_counts)
+        setAllUnmatchedStudyIds(all_unmatched)
+        setErrorDetail(null)
+      })
+      .catch((e: Error) => {
+        if (ignore) return
+
+        console.error(e)
+        setErrorDetail(e.message)
+      })
+
+    return () => {
+      ignore = true
+    }
+  }, [currentUserInput.values, locationParams, matchPages])
+
+  useEffect(() => {
+    setMarkedFields(
+      markRelevantMatchFields({
+        conditions,
+        criteria,
+        fields: config.fields,
+        unmatched: allUnmatchedStudyIds,
+        values: currentUserInput.values,
+        studies: studies,
+      })
+    )
+  }, [
+    conditions,
+    criteria,
+    config.fields,
+    currentUserInput,
+    studies,
+    allUnmatchedStudyIds,
+  ])
+
+  useEffect(() => {
+    if (triedBrowserLocation) return
+    if (!navigator.geolocation) return
+    if (locationFilter.lat || locationFilter.lon) return
+
+    setTriedBrowserLocation(true)
+
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        setLocationFilter({
+          ...locationFilter,
+          mode: 'coordinates',
+          lat: String(position.coords.latitude),
+          lon: String(position.coords.longitude),
+        })
+      },
+      (error) => {
+        console.error('Unable to get browser location', error)
+      }
+    )
+  }, [
+    triedBrowserLocation,
+    locationFilter.lat,
+    locationFilter.lon,
+    locationFilter,
+    setLocationFilter,
+  ])
+
+  function updateMatchInput(newMatchedInput: MatchFormValues) {
+    if (
+      JSON.stringify(newMatchedInput) !==
+      JSON.stringify(currentUserInput.values)
+    ) {
+      postUserInput(newMatchedInput, currentUserInput.id, currentUserInput.name)
+        .then((res) => {
+          setCurrentUserInput(res)
+          setErrorDetail(null)
+          if (showAllUserInput) {
+            setAllUserInput(
+              allUserInput.map((u) => {
+                if (u.id === res.id) {
+                  return res
+                } else {
+                  return u
+                }
+              })
+            )
+          }
+        })
+        .catch((e: Error) => setErrorDetail(e.message))
+    }
+  }
+
+  const patientValuesByFieldName = Object.fromEntries(
+    config.fields.flatMap((field) => {
+      const value = currentUserInput.values[field.id]
+      const names = [field.name, field.label].filter(
+        (name): name is string => typeof name === 'string' && name !== ''
+      )
+
+      return names.map((name) => [name, value])
+    })
+  )
+
+  function createMatchInput(name?: string) {
+    postUserInput({}, undefined, name).then((res) => {
+      setCurrentUserInput(res)
+      if (showAllUserInput) {
+        setAllUserInput([...allUserInput, res])
+      }
+    })
+  }
+
+  function handleReset() {
+    updateMatchInput(getDefaultValues(config))
+    setErrorDetail(null)
+  }
+
+  function toggleFilter() {
+    setIsFilterActive((isActive) => !isActive)
+  }
+
+  function loadUserInput(e: React.ChangeEvent<HTMLSelectElement>) {
+    const currentUserInput = allUserInput.find(
+      (userInput) => userInput.id === +e.target.value
+    )
+    if (currentUserInput) {
+      setCurrentUserInput(currentUserInput)
+    }
+  }
+
+  function changeMatchPage(group: MatchGroupKey, direction: -1 | 1) {
+    setMatchPages((pages) => {
+      const pageCount = Math.max(
+        1,
+        Math.ceil(matchCounts[group] / MATCH_PAGE_SIZE)
+      )
+
+      return {
+        ...pages,
+        [group]: Math.min(pageCount, Math.max(1, pages[group] + direction)),
+      }
+    })
+  }
+
+  function setMatchPage(group: MatchGroupKey, page: number) {
+    setMatchPages((pages) => {
+      const pageCount = Math.max(
+        1,
+        Math.ceil(matchCounts[group] / MATCH_PAGE_SIZE)
+      )
+
+      return {
+        ...pages,
+        [group]: Math.min(pageCount, Math.max(1, page)),
+      }
+    })
+  }
+
+  return {
+    isUpdating,
+    setIsUpdating,
+    isFilterActive,
+    matchDetails,
+    matchGroups,
+    matchCounts,
+    matchPages,
+    pageSize: MATCH_PAGE_SIZE,
+    allUnmatchedStudyIds,
+    allUserInput,
+    currentUserInput,
+    markedFields,
+    showAllUserInput,
+    errorDetail,
+    locationFilter,
+    setLocationFilter,
+    locationParams,
+    locationError,
+    applyLocationFilter,
+    clearLocationFilter,
+    isLocationActive,
+    isLocationResolving,
+    updateMatchInput,
+    patientValuesByFieldName,
+    createMatchInput,
+    handleReset,
+    toggleFilter,
+    loadUserInput,
+    changeMatchPage,
+    setMatchPage,
+    config,
+    studies,
+    fetchAll,
+  }
+}

--- a/src/pages/EnhancedMatchingPage.tsx
+++ b/src/pages/EnhancedMatchingPage.tsx
@@ -1,0 +1,383 @@
+import React, { useMemo, useState } from 'react'
+import {
+  MoreHorizontal,
+  RotateCcw,
+  ToggleLeft,
+  ToggleRight,
+} from 'react-feather'
+import ReactTooltip from 'react-tooltip'
+import { ErrorRetry } from '../components/ErrorRetry'
+import { useModal } from '../hooks/useModal'
+import { UserInputModal } from '../components/UserInputModal'
+import { LocationFilterSection } from '../components/LocationFilterSection'
+import type { MatchingPageProps } from './MatchingPage'
+import { useMatchingSession } from '../hooks/useMatchingSession'
+import { useFieldSearchIndex } from '../components/enhanced/useFieldSearchIndex'
+import { useManageItemScrollPosition } from '../hooks/useManageItemScrollPosition'
+import ThreePanelLayout from '../components/enhanced/ThreePanelLayout'
+import CategorySidebar from '../components/enhanced/CategorySidebar'
+import TypeaheadSearch from '../components/enhanced/TypeaheadSearch'
+import QuickSelect from '../components/enhanced/QuickSelect'
+import EnhancedMatchForm from '../components/enhanced/EnhancedMatchForm'
+import SelectedValuesBar from '../components/enhanced/SelectedValuesBar'
+import ResultsPanel from '../components/enhanced/ResultsPanel'
+import type { CategorySummary } from '../components/enhanced/types'
+
+function EnhancedMatchingPage({
+  action,
+  state,
+  status,
+  importantQuestionsConfig,
+}: MatchingPageProps) {
+  const { fetchAll } = action
+  const { config } = state
+
+  const session = useMatchingSession({
+    action,
+    state,
+    status,
+    importantQuestionsConfig,
+  })
+
+  const [showFormOptions, setShowFormOptions] = useState(false)
+  const [showModal, openModal, closeModal] = useModal()
+  const [activeCategoryId, setActiveCategoryId] = useState<number | null>(
+    config.groups.length > 0 ? config.groups[0].id : null
+  )
+  const [jumpBanner, setJumpBanner] = useState<string | null>(null)
+  const [highlightedFieldId, setHighlightedFieldId] = useState<number | null>(
+    null
+  )
+
+  const centerPanelRef = React.useRef<HTMLDivElement>(null)
+
+  const searchableFields = useFieldSearchIndex(
+    { groups: config.groups, fields: session.markedFields },
+    session.currentUserInput.values,
+    session.isFilterActive
+  )
+
+  const { createScrollItemRef } = useManageItemScrollPosition({
+    topOffset: 80,
+    behavior: 'smooth',
+    rootRef: centerPanelRef,
+  })
+
+  const categories: CategorySummary[] = useMemo(() => {
+    return config.groups.map((group) => {
+      const groupFields = session.markedFields.filter(
+        (field) => field.groupId === group.id
+      )
+
+      const visibleFields = groupFields.filter((field) => {
+        const isHidden = session.isFilterActive && !field.relevant
+        return !isHidden
+      })
+
+      const filledFields = visibleFields.filter(
+        (field) =>
+          session.currentUserInput.values[field.id] !== undefined &&
+          session.currentUserInput.values[field.id] !== ''
+      )
+
+      return {
+        id: group.id,
+        name: group.name,
+        visibleCount: visibleFields.length,
+        filledCount: filledFields.length,
+      }
+    })
+  }, [
+    config.groups,
+    session.markedFields,
+    session.currentUserInput.values,
+    session.isFilterActive,
+  ])
+
+  function handleSelectField(id: number) {
+    const field = session.markedFields.find((f) => f.id === id)
+    if (!field) return
+
+    setActiveCategoryId(field.groupId)
+
+    setTimeout(() => {
+      const scrollTarget = centerPanelRef.current?.querySelector(
+        `[data-field-id="${id}"]`
+      )
+      if (scrollTarget instanceof HTMLElement) {
+        scrollTarget.scrollIntoView({ behavior: 'smooth', block: 'center' })
+        const firstInput = scrollTarget.querySelector('input, select, textarea')
+        if (firstInput instanceof HTMLElement) {
+          firstInput.focus()
+        }
+      }
+      setHighlightedFieldId(id)
+      setTimeout(() => {
+        setHighlightedFieldId(null)
+      }, 2500)
+    }, 150)
+
+    const fieldLabel = field.label || field.name
+    setJumpBanner(`Jumped to: ${fieldLabel}`)
+    setTimeout(() => {
+      setJumpBanner(null)
+    }, 2500)
+  }
+
+  function handleClearField(id: number) {
+    const newValues = { ...session.currentUserInput.values }
+    delete newValues[id]
+    session.updateMatchInput(newValues)
+  }
+
+  function toggleFormOptions() {
+    setShowFormOptions((show) => !show)
+  }
+
+  function handleFormOptionsBlur(e: React.FocusEvent) {
+    if (showFormOptions && !e.currentTarget.contains(e.relatedTarget))
+      setShowFormOptions(false)
+  }
+
+  if (status === 'sending') return <div>Loading...</div>
+  if (status === 'error') {
+    return <ErrorRetry retry={fetchAll} />
+  }
+
+  const locationFilterSection = (
+    <LocationFilterSection
+      filter={session.locationFilter}
+      onChange={session.setLocationFilter}
+      onApply={session.applyLocationFilter}
+      onClear={session.clearLocationFilter}
+      isActive={session.isLocationActive}
+      error={session.locationError}
+      isResolving={session.isLocationResolving}
+    />
+  )
+
+  function handleSelectCategory(id: number) {
+    setActiveCategoryId(id)
+    setTimeout(() => {
+      const sectionHeader = centerPanelRef.current?.querySelector(
+        `[data-group-id="${id}"]`
+      )
+      if (sectionHeader instanceof HTMLElement) {
+        sectionHeader.scrollIntoView({ behavior: 'smooth', block: 'start' })
+      }
+    }, 150)
+  }
+
+  const sidebar = (
+    <div className="p-6">
+      <CategorySidebar
+        categories={categories}
+        activeCategoryId={activeCategoryId}
+        onSelectCategory={handleSelectCategory}
+      />
+    </div>
+  )
+
+  const form = (
+    <div ref={centerPanelRef} className="h-full overflow-y-auto">
+      {session.errorDetail && (
+        <div
+          role="alert"
+          aria-live="polite"
+          className="mx-4 my-3 rounded-md border border-red-300 bg-red-50 p-3 text-red-800"
+        >
+          <p className="text-sm">{session.errorDetail}</p>
+          <button
+            onClick={session.handleReset}
+            className="mt-2 underline decoration-red-400 hover:opacity-80"
+          >
+            Reset and start over
+          </button>
+        </div>
+      )}
+
+      <div className="sticky top-0 z-20 bg-white border-b border-gray-300">
+        <div className="px-4 py-3 flex justify-between items-center">
+          <h1 className="text-lg font-bold">Patient Information</h1>
+
+          <div
+            className="relative"
+            onBlur={handleFormOptionsBlur}
+            tabIndex={0} // eslint-disable-line jsx-a11y/no-noninteractive-tabindex
+          >
+            <button
+              className={`p-1 ${
+                showFormOptions ? 'text-primary' : 'hover:text-primary'
+              }`}
+              data-for="match-form-menu"
+              data-tip
+              onClick={toggleFormOptions}
+              aria-label="Options menu"
+            >
+              <MoreHorizontal />
+              <ReactTooltip
+                border
+                borderColor="black"
+                id="match-form-menu"
+                effect="solid"
+                place="left"
+                type="light"
+              >
+                <span>Options</span>
+              </ReactTooltip>
+            </button>
+            {showFormOptions && (
+              <div className="absolute right-0 origin-top-right w-44 bg-white border border-gray-300 shadow-md mt-2 p-1 z-30">
+                <ul className="w-full text-sm text-center text-primary">
+                  <li className="hover:bg-red-100">
+                    <button
+                      className="w-full p-2"
+                      data-for="match-form-filter"
+                      data-tip
+                      onClick={session.toggleFilter}
+                    >
+                      {session.isFilterActive ? (
+                        <ToggleRight className="inline" />
+                      ) : (
+                        <ToggleLeft className="inline text-gray-500" />
+                      )}
+                      <span className="mx-2">Filter fields</span>
+                    </button>
+                    <ReactTooltip
+                      border
+                      borderColor="black"
+                      id="match-form-filter"
+                      effect="solid"
+                      place="bottom"
+                      type="light"
+                    >
+                      <div style={{ maxWidth: '200px' }}>
+                        Filter to display the relevant fields only or see all
+                      </div>
+                    </ReactTooltip>
+                  </li>
+                  <li className="hover:bg-red-100">
+                    <button
+                      className="w-full p-2"
+                      data-for="match-form-reset"
+                      data-tip
+                      onClick={session.handleReset}
+                    >
+                      <RotateCcw className="inline" size="1rem" />
+                      <span className="mx-2">Reset form</span>
+                    </button>
+                    <ReactTooltip
+                      border
+                      borderColor="black"
+                      id="match-form-reset"
+                      effect="solid"
+                      place="bottom"
+                      type="light"
+                    >
+                      <span>Clear all fields</span>
+                    </ReactTooltip>
+                  </li>
+                </ul>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {session.showAllUserInput && (
+          <div className="px-4 pb-3">
+            <label htmlFor="user-input-select" className="block text-sm mb-1">
+              Select saved input:
+            </label>
+            <div className="flex gap-2">
+              <select
+                id="user-input-select"
+                className="flex-1 border border-solid border-black p-1"
+                value={session.currentUserInput.id ?? ''}
+                onChange={session.loadUserInput}
+              >
+                {session.allUserInput.map((input) => (
+                  <option key={input.id} value={input.id}>
+                    {input.name || `Input ${input.id}`}
+                  </option>
+                ))}
+              </select>
+              <button
+                onClick={openModal}
+                className="border border-solid border-black px-3 py-1 hover:bg-gray-100"
+              >
+                New
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {jumpBanner && (
+        <div className="sticky top-16 z-30 mx-4 mt-3">
+          <div className="bg-blue-100 border border-blue-300 text-blue-800 px-4 py-2 text-sm">
+            {jumpBanner}
+          </div>
+        </div>
+      )}
+
+      <div className="p-6 pb-96 space-y-6">
+        <TypeaheadSearch
+          fields={searchableFields}
+          onSelectField={handleSelectField}
+        />
+
+        <QuickSelect
+          fields={session.markedFields}
+          importantQuestionsConfig={importantQuestionsConfig}
+          onSelectField={handleSelectField}
+        />
+
+        <SelectedValuesBar
+          fields={session.markedFields}
+          values={session.currentUserInput.values}
+          onClearField={handleClearField}
+        />
+
+        <EnhancedMatchForm
+          config={{ groups: config.groups, fields: session.markedFields }}
+          matchInput={session.currentUserInput.values}
+          isFilterActive={session.isFilterActive}
+          updateMatchInput={session.updateMatchInput}
+          setIsUpdating={session.setIsUpdating}
+          importantQuestionsConfig={importantQuestionsConfig}
+          locationFilterSection={locationFilterSection}
+          activeCategoryId={activeCategoryId}
+          onActiveCategoryChange={setActiveCategoryId}
+          registerScrollTarget={createScrollItemRef}
+          highlightedFieldId={highlightedFieldId}
+        />
+      </div>
+
+      {showModal && (
+        <UserInputModal
+          closeModal={closeModal}
+          createMatchInput={session.createMatchInput}
+        />
+      )}
+    </div>
+  )
+
+  const results = (
+    <ResultsPanel
+      matchDetails={session.matchDetails}
+      matchGroups={session.matchGroups}
+      studies={state.studies}
+      matchCounts={session.matchCounts}
+      pageSize={session.pageSize}
+      matchPages={session.matchPages}
+      onChangeMatchPage={session.changeMatchPage}
+      onSetMatchPage={session.setMatchPage}
+      patientValuesByFieldName={session.patientValuesByFieldName}
+      isUpdating={session.isUpdating}
+    />
+  )
+
+  return <ThreePanelLayout sidebar={sidebar} form={form} results={results} />
+}
+
+export default EnhancedMatchingPage


### PR DESCRIPTION
## Google Summer of Code 2026 — Data for the Common Good

Contributor: Manjula Kudapa

### Project summary

This project enhances the user experience of the GEARBOx trial matching form by implementing an intelligent field discovery system that transforms the cumbersome scrolling experience into a dynamic, search-driven interface. It introduces a typeahead
search with intelligent field filtering, allowing clinicians to rapidly locate and select only the data fields relevant to their patient, eliminating the need to scrollthrough hundreds of questions and significantly accelerating the matching process.

### Problem

The current matching form presents every trial-related question in a single scrolling column. Finding the fields relevant to a particular patient means scrolling past hundreds that don't apply, which slows the matching process and increases the risk of
incomplete data entry.

### What was built

**Three-panel layout** (`ThreePanelLayout.tsx`)
Category navigation on the left, the form in the centre, live trial results on the right, each scrolling independently. On mobile the sidebar becomes a horizontal strip and the centre and right panels switch using the existing Patient Info / Open Trials
toggle.

**Typeahead field search** (`TypeaheadSearch.tsx`, `useFieldSearchIndex.ts`)
Matches the query against a field's name, its label, and its category name, returningup to eight results. Each result shows the field name with its category beneath. Selecting one expands that category, collapses the others, scrolls the field into the centre of the viewport, focuses the input, and highlights it briefly. Fields currently hidden by an unmet `showIf` condition still appear in results, de-emphasised, and selecting one jumps to the trigger field that would reveal it. Full keyboard support:
arrow keys move through results, Enter selects, Escape closes.

**Category sidebar** (`CategorySidebar.tsx`)
The five form categories as navigation. Clicking one expands that section and collapses the rest, then scrolls it to the top of the panel. The active category also updates as the clinician scrolls, tracked with an `IntersectionObserver`.

**Enhanced form** (`EnhancedMatchForm.tsx`)
Renders the same fields as `MatchForm` in accordion sections grouped by category, with a two-column grid layout. Section open state is derived from a single source of truth rather than held separately, which avoids the sidebar and the scroll observer fighting over it.

**Quick select** (`QuickSelect.tsx`)
Buttons for the fields marked in `importantQuestionsConfig`, jumping straight to them without searching. Derived from config, not hardcoded.

**Selected values** (`SelectedValuesBar.tsx`)
Filled fields shown as chips with their resolved option labels, each clearable.

**Results panel** (`ResultsPanel.tsx`, `TrialBlockingCriteria.tsx`, `getBlockingCriteria.ts`)
The three result groups with server-side pagination, plus a line on each Potential Match naming up to two criteria that are missing patient data — so a clinician can see what would move a trial into a match without opening each card.

**Session hook** (`useMatchingSession.ts`)
The state and data flow from `MatchingPage` extracted into a reusable hook: user input fetching and persistence, `getMatchInfo` with pagination, location filtering, browser geolocation, and relevant-field marking. This avoids duplicating that logic between the two pages.

### Files

14 new files under `src/components/enhanced/`, plus `src/hooks/useMatchingSession.ts`
and `src/pages/EnhancedMatchingPage.tsx`. Three lines each in `App.tsx` and
`Layout.tsx`. No other existing files are modified.

`src/components/enhanced/README.md` documents the components and the accessibility
behaviour of the typeahead.

### Running it locally

The flag is not committed, so a fresh checkout renders the existing UI. To see the
enhanced page:

1. Add `REACT_APP_ENHANCED_UI=true` to `.env.production`
2. Build the portal image:
   `nerdctl --namespace k8s.io build -f Dockerfile -t gearbox_fe:enhanced .`
3. Point `portal.image` at `gearbox_fe:enhanced` with `pullPolicy: Never` in both
   `gearbox-default-values.yaml` and `secret-values.yaml`
4. `helm upgrade` and roll the portal deployment